### PR TITLE
Add URL-based room joining for multi and n-multi modes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -52,7 +52,7 @@ io.on('connection', (socket) => {
         };
         
         socket.join(roomId);
-        socket.emit('room_joined', { roomId, isHost: true });
+        socket.emit('room_joined', { roomId, isHost: true, roomName });
         io.emit('room_list', getRoomList()); // Broadcast update
         console.log(`Room created: ${roomName} (${roomId})`);
     });
@@ -62,9 +62,9 @@ io.on('connection', (socket) => {
         if (room && room.status === 'waiting' && !room.p2) {
             room.p2 = socket.id;
             room.status = 'playing';
-            
+
             socket.join(roomId);
-            socket.emit('room_joined', { roomId, isHost: false });
+            socket.emit('room_joined', { roomId, isHost: false, roomName: room.name });
             
             // Notify P1 (host)
             io.to(room.p1).emit('opponent_joined', { opponentId: socket.id });
@@ -114,6 +114,49 @@ io.on('connection', (socket) => {
         }
     });
 
+    socket.on('join_or_create', (data) => {
+        const roomName = (data && data.roomName) || 'Room';
+
+        // Find existing waiting room by name
+        let existingRoomId = null;
+        for (const roomId in rooms) {
+            if (rooms[roomId].name === roomName && rooms[roomId].status === 'waiting') {
+                existingRoomId = roomId;
+                break;
+            }
+        }
+
+        if (existingRoomId) {
+            // Join existing room as p2
+            const room = rooms[existingRoomId];
+            room.p2 = socket.id;
+            room.status = 'playing';
+
+            socket.join(existingRoomId);
+            socket.emit('room_joined', { roomId: existingRoomId, isHost: false, roomName: room.name });
+
+            io.to(room.p1).emit('opponent_joined', { opponentId: socket.id });
+            socket.emit('opponent_joined', { opponentId: room.p1 });
+
+            io.emit('room_list', getRoomList());
+        } else {
+            // Create new room
+            const roomId = crypto.randomUUID();
+            rooms[roomId] = {
+                id: roomId,
+                name: roomName,
+                p1: socket.id,
+                p2: null,
+                status: 'waiting'
+            };
+
+            socket.join(roomId);
+            socket.emit('room_joined', { roomId, isHost: true, roomName });
+            io.emit('room_list', getRoomList());
+            console.log(`Room created via join_or_create: ${roomName} (${roomId})`);
+        }
+    });
+
     // ===== N-Multi Events =====
 
     socket.on('nmulti_get_rooms', () => {
@@ -154,6 +197,7 @@ io.on('connection', (socket) => {
             roomId,
             playerId: socket.id,
             playerName,
+            roomName: room.name,
             players: getPlayersMap(room)
         });
 
@@ -196,6 +240,7 @@ io.on('connection', (socket) => {
             roomId,
             playerId: socket.id,
             playerName,
+            roomName: room.name,
             players: getPlayersMap(room)
         });
 
@@ -286,6 +331,7 @@ io.on('connection', (socket) => {
                 roomId: existingRoomId,
                 playerId: socket.id,
                 playerName,
+                roomName: room.name,
                 players: getPlayersMap(room)
             });
 
@@ -327,6 +373,7 @@ io.on('connection', (socket) => {
                 roomId,
                 playerId: socket.id,
                 playerName,
+                roomName,
                 players: getPlayersMap(nMultiRooms[roomId])
             });
 

--- a/src/tetris/scenes/lobbyScene.ts
+++ b/src/tetris/scenes/lobbyScene.ts
@@ -10,6 +10,7 @@ interface LobbyConfig {
     title: string;
     playScene: string;
     maxPlayers: number;
+    urlPrefix: string;
     events: {
         getRooms: string;
         roomList: string;
@@ -26,6 +27,7 @@ const MULTI_CONFIG: LobbyConfig = {
     title: 'LOBBY',
     playScene: 'PlayScene',
     maxPlayers: 2,
+    urlPrefix: '/multi',
     events: {
         getRooms: 'get_rooms',
         roomList: 'room_list',
@@ -39,6 +41,7 @@ const MULTI_CONFIG: LobbyConfig = {
         socket,
         roomId: data.roomId,
         isHost: data.isHost,
+        roomName: data.roomName,
     }),
 };
 
@@ -47,6 +50,7 @@ const NMULTI_CONFIG: LobbyConfig = {
     title: 'N-MULTI',
     playScene: 'NMultiPlayScene',
     maxPlayers: 100,
+    urlPrefix: '/n-multi',
     events: {
         getRooms: 'nmulti_get_rooms',
         roomList: 'nmulti_room_list',
@@ -61,6 +65,7 @@ const NMULTI_CONFIG: LobbyConfig = {
         playerId: data.playerId,
         playerName: data.playerName,
         initialPlayers: data.players,
+        roomName: data.roomName,
     }),
 };
 
@@ -115,6 +120,9 @@ class BaseLobbyScene extends BaseScene {
         });
 
         this.socket.on(events.roomJoined, (data: any) => {
+            if (data.roomName) {
+                history.replaceState(null, '', this.lobbyConfig.urlPrefix + '/' + encodeURIComponent(data.roomName));
+            }
             this.scene.start(this.lobbyConfig.playScene, this.lobbyConfig.buildSceneData(this.socket, data));
         });
 

--- a/src/tetris/scenes/menuScene.ts
+++ b/src/tetris/scenes/menuScene.ts
@@ -35,8 +35,15 @@ export class MenuScene extends BaseScene {
         const nMultiMatch = window.location.pathname.match(/^\/n-multi\/(.+)$/);
         if (nMultiMatch) {
             const roomName = decodeURIComponent(nMultiMatch[1]);
-            history.replaceState(null, '', '/');
-            this.joinRoomByUrl(roomName);
+            this.joinNMultiRoomByUrl(roomName);
+            return;
+        }
+
+        // Check for /multi/{roomName} URL pattern
+        const multiMatch = window.location.pathname.match(/^\/multi\/(.+)$/);
+        if (multiMatch) {
+            const roomName = decodeURIComponent(multiMatch[1]);
+            this.joinMultiRoomByUrl(roomName);
             return;
         }
 
@@ -46,7 +53,7 @@ export class MenuScene extends BaseScene {
         this.resize(window.innerWidth, window.innerHeight);
     }
 
-    private joinRoomByUrl(roomName: string): void {
+    private joinNMultiRoomByUrl(roomName: string): void {
         // Show connecting text
         const connectingText = this.add.text(this.GAME_WIDTH / 2, this.GAME_HEIGHT / 2, 'Connecting...', {
             fontSize: '32px',
@@ -68,7 +75,8 @@ export class MenuScene extends BaseScene {
                 roomId: data.roomId,
                 playerId: data.playerId,
                 playerName: data.playerName,
-                initialPlayers: data.players
+                initialPlayers: data.players,
+                roomName: roomName
             });
         });
 
@@ -76,6 +84,7 @@ export class MenuScene extends BaseScene {
             connectingText.destroy();
             socket.disconnect();
             alert('Failed to join room: ' + msg);
+            history.replaceState(null, '', '/');
             this.createDOMUI();
             this.resize(window.innerWidth, window.innerHeight);
         });
@@ -84,6 +93,51 @@ export class MenuScene extends BaseScene {
             connectingText.destroy();
             socket.disconnect();
             alert('Failed to connect to server.');
+            history.replaceState(null, '', '/');
+            this.createDOMUI();
+            this.resize(window.innerWidth, window.innerHeight);
+        });
+    }
+
+    private joinMultiRoomByUrl(roomName: string): void {
+        const connectingText = this.add.text(this.GAME_WIDTH / 2, this.GAME_HEIGHT / 2, 'Connecting...', {
+            fontSize: '32px',
+            color: '#ffffff',
+            stroke: '#000000',
+            strokeThickness: 4
+        }).setOrigin(0.5);
+
+        const socket: Socket = io(getSocketUrl(), { path: SOCKET_PATH });
+
+        socket.on('connect', () => {
+            socket.emit('join_or_create', { roomName });
+        });
+
+        socket.on('room_joined', (data: any) => {
+            connectingText.destroy();
+            this.scene.start("PlayScene", {
+                mode: 'multi',
+                socket,
+                roomId: data.roomId,
+                isHost: data.isHost,
+                roomName: roomName
+            });
+        });
+
+        socket.on('room_error', (msg: string) => {
+            connectingText.destroy();
+            socket.disconnect();
+            alert('Failed to join room: ' + msg);
+            history.replaceState(null, '', '/');
+            this.createDOMUI();
+            this.resize(window.innerWidth, window.innerHeight);
+        });
+
+        socket.on('connect_error', () => {
+            connectingText.destroy();
+            socket.disconnect();
+            alert('Failed to connect to server.');
+            history.replaceState(null, '', '/');
             this.createDOMUI();
             this.resize(window.innerWidth, window.innerHeight);
         });

--- a/src/tetris/scenes/nMultiPlayScene.ts
+++ b/src/tetris/scenes/nMultiPlayScene.ts
@@ -21,6 +21,7 @@ export class NMultiPlayScene extends BaseScene {
     private isPause: boolean = false;
     private socket: Socket;
     private roomId: string;
+    private roomName: string;
     private playerId: string;
     private playerName: string;
     private statusText: Phaser.GameObjects.Text;
@@ -48,6 +49,7 @@ export class NMultiPlayScene extends BaseScene {
 
         this.socket = data.socket;
         this.roomId = data.roomId;
+        this.roomName = data.roomName;
         this.playerId = data.playerId;
         this.playerName = data.playerName;
 
@@ -277,6 +279,7 @@ export class NMultiPlayScene extends BaseScene {
         if (this.socket) {
             this.socket.emit('nmulti_leave_room', { roomId: this.roomId });
         }
+        history.replaceState(null, '', '/');
         this.scene.start("NMultiLobbyScene");
     }
 
@@ -296,6 +299,7 @@ export class NMultiPlayScene extends BaseScene {
         this.scene.restart({
             socket: this.socket,
             roomId: this.roomId,
+            roomName: this.roomName,
             playerId: this.playerId,
             playerName: this.playerName,
             initialPlayers: this.snapshotPlayers

--- a/src/tetris/scenes/playScene.ts
+++ b/src/tetris/scenes/playScene.ts
@@ -37,6 +37,7 @@ export class PlayScene extends BaseScene {
     private lastUpdateSend: number = 0;
     private isGameRunning: boolean = false;
     private mode: string = 'single';
+    private roomName: string;
     private isGameEnded: boolean = false;
 
     // Configurable Scales
@@ -54,6 +55,7 @@ export class PlayScene extends BaseScene {
         this.GAME_HEIGHT = BLOCK_SIZE * 22;
 
         this.mode = data.mode || 'single';
+        this.roomName = data.roomName;
         if (this.mode === 'multi') {
             this.socket = data.socket;
             this.roomId = data.roomId;
@@ -133,10 +135,11 @@ export class PlayScene extends BaseScene {
             });
 
             this.socket.on('restart_signal', () => {
-                this.scene.restart({ mode: 'multi', socket: this.socket, roomId: this.roomId });
+                this.scene.restart({ mode: 'multi', socket: this.socket, roomId: this.roomId, roomName: this.roomName });
             });
 
             this.socket.on('opponent_disconnected', () => {
+                history.replaceState(null, '', '/');
                 alert('Opponent disconnected!');
                 this.scene.start('LobbyScene');
             });
@@ -193,6 +196,10 @@ export class PlayScene extends BaseScene {
         this.time.paused = false;
         if (this.socket) {
             this.socket.disconnect();
+        }
+
+        if (this.mode === 'multi') {
+            history.replaceState(null, '', '/');
         }
 
         if (this.mode === 'single') {

--- a/test/unit/server/multiServer.test.ts
+++ b/test/unit/server/multiServer.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for 1v1 Multiplayer server logic.
+ * Since the server functions are not exported, we test the logic patterns directly
+ * by simulating the data structures and operations used in server/index.js.
+ */
+
+describe('1v1 Multi Server Logic', () => {
+    // Simulate the server data structures
+    let rooms: Record<string, any>;
+
+    beforeEach(() => {
+        rooms = {};
+    });
+
+    // ===== Helper function replicas =====
+
+    function getRoomList() {
+        return Object.values(rooms).map((r: any) => ({
+            id: r.id,
+            name: r.name,
+            players: (r.p1 ? 1 : 0) + (r.p2 ? 1 : 0),
+            status: r.status
+        })).filter((r: any) => r.status === 'waiting');
+    }
+
+    function createRoom(socketId: string, roomName: string): { roomId: string, response: any } {
+        const roomId = 'room-' + Math.random().toString(36).slice(2);
+        rooms[roomId] = {
+            id: roomId,
+            name: roomName,
+            p1: socketId,
+            p2: null,
+            status: 'waiting'
+        };
+        return {
+            roomId,
+            response: { roomId, isHost: true, roomName }
+        };
+    }
+
+    function joinRoom(socketId: string, roomId: string): { success: boolean, response?: any, error?: string } {
+        const room = rooms[roomId];
+        if (room && room.status === 'waiting' && !room.p2) {
+            room.p2 = socketId;
+            room.status = 'playing';
+            return {
+                success: true,
+                response: { roomId, isHost: false, roomName: room.name }
+            };
+        }
+        return { success: false, error: 'Room is full or does not exist.' };
+    }
+
+    function joinOrCreate(socketId: string, roomName: string): { roomId: string, response: any, created: boolean } {
+        // Find existing waiting room by name
+        let existingRoomId: string | null = null;
+        for (const roomId in rooms) {
+            if (rooms[roomId].name === roomName && rooms[roomId].status === 'waiting') {
+                existingRoomId = roomId;
+                break;
+            }
+        }
+
+        if (existingRoomId) {
+            const room = rooms[existingRoomId];
+            room.p2 = socketId;
+            room.status = 'playing';
+            return {
+                roomId: existingRoomId,
+                response: { roomId: existingRoomId, isHost: false, roomName: room.name },
+                created: false
+            };
+        } else {
+            const roomId = 'room-' + Math.random().toString(36).slice(2);
+            rooms[roomId] = {
+                id: roomId,
+                name: roomName,
+                p1: socketId,
+                p2: null,
+                status: 'waiting'
+            };
+            return {
+                roomId,
+                response: { roomId, isHost: true, roomName },
+                created: true
+            };
+        }
+    }
+
+    function cleanupDisconnect(socketId: string): string[] {
+        const deletedRooms: string[] = [];
+        for (const roomId in rooms) {
+            const room = rooms[roomId];
+            if (room.p1 === socketId || room.p2 === socketId) {
+                delete rooms[roomId];
+                deletedRooms.push(roomId);
+            }
+        }
+        return deletedRooms;
+    }
+
+    // ===== Tests =====
+
+    describe('getRoomList', () => {
+        test('returns empty array when no rooms', () => {
+            expect(getRoomList()).toEqual([]);
+        });
+
+        test('returns only waiting rooms', () => {
+            rooms['room1'] = { id: 'room1', name: 'Waiting Room', p1: 's1', p2: null, status: 'waiting' };
+            rooms['room2'] = { id: 'room2', name: 'Playing Room', p1: 's2', p2: 's3', status: 'playing' };
+
+            const list = getRoomList();
+            expect(list).toHaveLength(1);
+            expect(list[0].name).toBe('Waiting Room');
+            expect(list[0].players).toBe(1);
+        });
+
+        test('counts players correctly', () => {
+            rooms['room1'] = { id: 'room1', name: 'Room', p1: 's1', p2: null, status: 'waiting' };
+            const list = getRoomList();
+            expect(list[0].players).toBe(1);
+        });
+
+        test('returns multiple waiting rooms', () => {
+            rooms['room1'] = { id: 'room1', name: 'Room A', p1: 's1', p2: null, status: 'waiting' };
+            rooms['room2'] = { id: 'room2', name: 'Room B', p1: 's2', p2: null, status: 'waiting' };
+
+            const list = getRoomList();
+            expect(list).toHaveLength(2);
+        });
+    });
+
+    describe('Room Creation', () => {
+        test('creates room with correct structure', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            const room = rooms[roomId];
+
+            expect(room.name).toBe('My Room');
+            expect(room.p1).toBe('socket1');
+            expect(room.p2).toBeNull();
+            expect(room.status).toBe('waiting');
+        });
+
+        test('response includes roomName', () => {
+            const { response } = createRoom('socket1', 'Test Room');
+
+            expect(response.isHost).toBe(true);
+            expect(response.roomName).toBe('Test Room');
+            expect(response.roomId).toBeDefined();
+        });
+
+        test('creating multiple rooms works independently', () => {
+            const r1 = createRoom('socket1', 'Room A');
+            const r2 = createRoom('socket2', 'Room B');
+
+            expect(rooms[r1.roomId].name).toBe('Room A');
+            expect(rooms[r2.roomId].name).toBe('Room B');
+            expect(Object.keys(rooms)).toHaveLength(2);
+        });
+    });
+
+    describe('Room Joining', () => {
+        test('joins waiting room as p2', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            const result = joinRoom('socket2', roomId);
+
+            expect(result.success).toBe(true);
+            expect(result.response!.isHost).toBe(false);
+            expect(result.response!.roomName).toBe('My Room');
+            expect(rooms[roomId].p2).toBe('socket2');
+            expect(rooms[roomId].status).toBe('playing');
+        });
+
+        test('rejects join when room is full', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            joinRoom('socket2', roomId); // p2 joins
+
+            const result = joinRoom('socket3', roomId);
+            expect(result.success).toBe(false);
+            expect(result.error).toBe('Room is full or does not exist.');
+        });
+
+        test('rejects join for non-existent room', () => {
+            const result = joinRoom('socket1', 'nonexistent');
+            expect(result.success).toBe(false);
+            expect(result.error).toBe('Room is full or does not exist.');
+        });
+
+        test('rejects join when room is already playing', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            rooms[roomId].status = 'playing';
+            rooms[roomId].p2 = 'socket2';
+
+            const result = joinRoom('socket3', roomId);
+            expect(result.success).toBe(false);
+        });
+    });
+
+    describe('Join or Create', () => {
+        test('creates new room when no matching name exists', () => {
+            const result = joinOrCreate('socket1', 'New Room');
+
+            expect(result.created).toBe(true);
+            expect(result.response.isHost).toBe(true);
+            expect(result.response.roomName).toBe('New Room');
+            expect(rooms[result.roomId].p1).toBe('socket1');
+            expect(rooms[result.roomId].status).toBe('waiting');
+        });
+
+        test('joins existing waiting room by name', () => {
+            const { roomId } = createRoom('socket1', 'Shared Room');
+
+            const result = joinOrCreate('socket2', 'Shared Room');
+            expect(result.created).toBe(false);
+            expect(result.roomId).toBe(roomId);
+            expect(result.response.isHost).toBe(false);
+            expect(result.response.roomName).toBe('Shared Room');
+            expect(rooms[roomId].p2).toBe('socket2');
+            expect(rooms[roomId].status).toBe('playing');
+        });
+
+        test('ignores rooms that are already playing', () => {
+            const { roomId } = createRoom('socket1', 'Busy Room');
+            rooms[roomId].p2 = 'socket2';
+            rooms[roomId].status = 'playing';
+
+            const result = joinOrCreate('socket3', 'Busy Room');
+            expect(result.created).toBe(true);
+            expect(result.roomId).not.toBe(roomId);
+            expect(result.response.isHost).toBe(true);
+        });
+
+        test('creates new room when existing room with same name is full', () => {
+            const { roomId: firstRoomId } = createRoom('socket1', 'Popular Room');
+            joinRoom('socket2', firstRoomId);
+
+            const result = joinOrCreate('socket3', 'Popular Room');
+            expect(result.created).toBe(true);
+            expect(result.roomId).not.toBe(firstRoomId);
+        });
+
+        test('response always includes roomName', () => {
+            // Created case
+            const created = joinOrCreate('socket1', 'Test Room');
+            expect(created.response.roomName).toBe('Test Room');
+
+            // Joined case
+            const joined = joinOrCreate('socket2', 'Test Room');
+            expect(joined.response.roomName).toBe('Test Room');
+        });
+
+        test('handles rooms with different names correctly', () => {
+            createRoom('socket1', 'Room A');
+            createRoom('socket2', 'Room B');
+
+            const result = joinOrCreate('socket3', 'Room A');
+            expect(result.created).toBe(false);
+            expect(result.response.roomName).toBe('Room A');
+            // Room B should remain untouched
+            const roomBId = Object.keys(rooms).find(id => rooms[id].name === 'Room B');
+            expect(rooms[roomBId!].status).toBe('waiting');
+        });
+    });
+
+    describe('Player Ready and Game Start', () => {
+        test('tracks ready state per player', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            joinRoom('socket2', roomId);
+            const room = rooms[roomId];
+
+            // P1 ready
+            room.p1Ready = true;
+            expect(room.p1Ready).toBe(true);
+            expect(room.p2Ready).toBeUndefined();
+        });
+
+        test('game starts when both players are ready', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            joinRoom('socket2', roomId);
+            const room = rooms[roomId];
+
+            room.p1Ready = true;
+            room.p2Ready = true;
+            expect(room.p1Ready && room.p2Ready).toBe(true);
+        });
+
+        test('game does not start with only one player ready', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            joinRoom('socket2', roomId);
+            const room = rooms[roomId];
+
+            room.p1Ready = true;
+            room.p2Ready = false;
+            expect(room.p1Ready && room.p2Ready).toBe(false);
+        });
+    });
+
+    describe('Restart Logic', () => {
+        test('resets both ready states on restart', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            joinRoom('socket2', roomId);
+            const room = rooms[roomId];
+
+            room.p1Ready = true;
+            room.p2Ready = true;
+
+            // Restart
+            room.p1Ready = false;
+            room.p2Ready = false;
+
+            expect(room.p1Ready).toBe(false);
+            expect(room.p2Ready).toBe(false);
+        });
+    });
+
+    describe('Disconnect Cleanup', () => {
+        test('removes room when a player disconnects', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            joinRoom('socket2', roomId);
+
+            const deleted = cleanupDisconnect('socket1');
+            expect(deleted).toContain(roomId);
+            expect(rooms[roomId]).toBeUndefined();
+        });
+
+        test('cleans up room where player is host (p1)', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+
+            const deleted = cleanupDisconnect('socket1');
+            expect(deleted).toContain(roomId);
+            expect(rooms[roomId]).toBeUndefined();
+        });
+
+        test('cleans up room where player is guest (p2)', () => {
+            const { roomId } = createRoom('socket1', 'My Room');
+            joinRoom('socket2', roomId);
+
+            const deleted = cleanupDisconnect('socket2');
+            expect(deleted).toContain(roomId);
+            expect(rooms[roomId]).toBeUndefined();
+        });
+
+        test('does not affect rooms player is not in', () => {
+            createRoom('socket1', 'Room A');
+            createRoom('socket2', 'Room B');
+
+            cleanupDisconnect('socket1');
+            const remainingRoomIds = Object.keys(rooms);
+            expect(remainingRoomIds).toHaveLength(1);
+            expect(rooms[remainingRoomIds[0]].name).toBe('Room B');
+        });
+
+        test('handles disconnect when player has no rooms', () => {
+            createRoom('socket1', 'Room A');
+
+            const deleted = cleanupDisconnect('socket99');
+            expect(deleted).toHaveLength(0);
+            expect(Object.keys(rooms)).toHaveLength(1);
+        });
+    });
+
+    describe('Room Response Data', () => {
+        test('create_room response includes roomName', () => {
+            const { response } = createRoom('socket1', 'Test Room');
+            expect(response).toEqual({
+                roomId: expect.any(String),
+                isHost: true,
+                roomName: 'Test Room'
+            });
+        });
+
+        test('join_room response includes roomName', () => {
+            const { roomId } = createRoom('socket1', 'Test Room');
+            const result = joinRoom('socket2', roomId);
+            expect(result.response).toEqual({
+                roomId,
+                isHost: false,
+                roomName: 'Test Room'
+            });
+        });
+
+        test('join_or_create response includes roomName on create', () => {
+            const result = joinOrCreate('socket1', 'URL Room');
+            expect(result.response.roomName).toBe('URL Room');
+        });
+
+        test('join_or_create response includes roomName on join', () => {
+            createRoom('socket1', 'URL Room');
+            const result = joinOrCreate('socket2', 'URL Room');
+            expect(result.response.roomName).toBe('URL Room');
+        });
+    });
+});

--- a/test/unit/server/nMultiServer.test.ts
+++ b/test/unit/server/nMultiServer.test.ts
@@ -532,4 +532,106 @@ describe('N-Multi Server Logic', () => {
             expect(nMultiRooms['room1']).toBeUndefined();
         });
     });
+
+    describe('Room Response Data (roomName)', () => {
+        function buildRoomJoinedResponse(room: any, socketId: string, playerName: string) {
+            return {
+                roomId: room.id,
+                playerId: socketId,
+                playerName,
+                roomName: room.name,
+                players: getPlayersMap(room)
+            };
+        }
+
+        test('nmulti_create_room response includes roomName', () => {
+            const roomId = 'room-1';
+            const socketId = 'socket1';
+            nMultiRooms[roomId] = {
+                id: roomId,
+                name: 'Created Room',
+                playerCounter: 1,
+                players: {
+                    [socketId]: { name: 'Player1', score: 0, level: 1, lines: 0, board: null, isAlive: true }
+                }
+            };
+
+            const response = buildRoomJoinedResponse(nMultiRooms[roomId], socketId, 'Player1');
+            expect(response.roomName).toBe('Created Room');
+            expect(response.roomId).toBe(roomId);
+            expect(response.playerId).toBe(socketId);
+        });
+
+        test('nmulti_join_room response includes roomName', () => {
+            const roomId = 'room-1';
+            nMultiRooms[roomId] = {
+                id: roomId,
+                name: 'Existing Room',
+                playerCounter: 2,
+                players: {
+                    'socket1': { name: 'Player1', score: 0, level: 1, lines: 0, board: null, isAlive: true },
+                    'socket2': { name: 'Player2', score: 0, level: 1, lines: 0, board: null, isAlive: true }
+                }
+            };
+
+            const response = buildRoomJoinedResponse(nMultiRooms[roomId], 'socket2', 'Player2');
+            expect(response.roomName).toBe('Existing Room');
+        });
+
+        test('nmulti_join_or_create response includes roomName on create', () => {
+            const roomName = 'New JoC Room';
+            const roomId = 'room-joc';
+            const socketId = 'socket1';
+
+            // No existing room found, create new
+            nMultiRooms[roomId] = {
+                id: roomId,
+                name: roomName,
+                playerCounter: 1,
+                players: {
+                    [socketId]: { name: 'Player1', score: 0, level: 1, lines: 0, board: null, isAlive: true }
+                }
+            };
+
+            const response = buildRoomJoinedResponse(nMultiRooms[roomId], socketId, 'Player1');
+            expect(response.roomName).toBe(roomName);
+        });
+
+        test('nmulti_join_or_create response includes roomName on join', () => {
+            const roomId = 'existing-room';
+            nMultiRooms[roomId] = {
+                id: roomId,
+                name: 'Popular Room',
+                playerCounter: 1,
+                players: {
+                    'socket1': { name: 'Player1', score: 0, level: 1, lines: 0, board: null, isAlive: true }
+                }
+            };
+
+            // Simulate join_or_create finding existing room
+            const room = nMultiRooms[roomId];
+            room.playerCounter++;
+            room.players['socket2'] = { name: 'Player2', score: 0, level: 1, lines: 0, board: null, isAlive: true };
+
+            const response = buildRoomJoinedResponse(room, 'socket2', 'Player2');
+            expect(response.roomName).toBe('Popular Room');
+            expect(response.players).toBeDefined();
+            expect(Object.keys(response.players)).toHaveLength(2);
+        });
+
+        test('roomName with special characters is preserved', () => {
+            const roomId = 'room-special';
+            nMultiRooms[roomId] = {
+                id: roomId,
+                name: '테스트 방 #1',
+                playerCounter: 1,
+                players: {
+                    'socket1': { name: 'Player1', score: 0, level: 1, lines: 0, board: null, isAlive: true }
+                }
+            };
+
+            const response = buildRoomJoinedResponse(nMultiRooms[roomId], 'socket1', 'Player1');
+            expect(response.roomName).toBe('테스트 방 #1');
+        });
+    });
 });

--- a/test/unit/urlRouting.test.ts
+++ b/test/unit/urlRouting.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for URL-based room routing.
+ * Tests URL pattern matching, encoding/decoding, and history state management
+ * used by MenuScene, LobbyScene, PlayScene, and NMultiPlayScene.
+ */
+
+describe('URL Routing', () => {
+
+    describe('N-Multi URL Pattern (/n-multi/{roomName})', () => {
+        const pattern = /^\/n-multi\/(.+)$/;
+
+        test('matches valid room name', () => {
+            const match = '/n-multi/MyRoom'.match(pattern);
+            expect(match).not.toBeNull();
+            expect(match![1]).toBe('MyRoom');
+        });
+
+        test('matches room name with spaces (encoded)', () => {
+            const match = '/n-multi/My%20Room'.match(pattern);
+            expect(match).not.toBeNull();
+            expect(decodeURIComponent(match![1])).toBe('My Room');
+        });
+
+        test('matches room name with special characters', () => {
+            const match = '/n-multi/room%23123'.match(pattern);
+            expect(match).not.toBeNull();
+            expect(decodeURIComponent(match![1])).toBe('room#123');
+        });
+
+        test('matches room name with unicode characters', () => {
+            const encoded = '/n-multi/' + encodeURIComponent('테스트방');
+            const match = encoded.match(pattern);
+            expect(match).not.toBeNull();
+            expect(decodeURIComponent(match![1])).toBe('테스트방');
+        });
+
+        test('matches room name with slashes', () => {
+            const match = '/n-multi/room/sub'.match(pattern);
+            expect(match).not.toBeNull();
+            expect(match![1]).toBe('room/sub');
+        });
+
+        test('does not match bare /n-multi/', () => {
+            const match = '/n-multi/'.match(pattern);
+            expect(match).toBeNull();
+        });
+
+        test('does not match /n-multi without trailing slash', () => {
+            const match = '/n-multi'.match(pattern);
+            expect(match).toBeNull();
+        });
+
+        test('does not match root path /', () => {
+            const match = '/'.match(pattern);
+            expect(match).toBeNull();
+        });
+
+        test('does not match /multi/ path', () => {
+            const match = '/multi/MyRoom'.match(pattern);
+            expect(match).toBeNull();
+        });
+    });
+
+    describe('1v1 Multi URL Pattern (/multi/{roomName})', () => {
+        const pattern = /^\/multi\/(.+)$/;
+
+        test('matches valid room name', () => {
+            const match = '/multi/MyRoom'.match(pattern);
+            expect(match).not.toBeNull();
+            expect(match![1]).toBe('MyRoom');
+        });
+
+        test('matches room name with spaces (encoded)', () => {
+            const match = '/multi/My%20Room'.match(pattern);
+            expect(match).not.toBeNull();
+            expect(decodeURIComponent(match![1])).toBe('My Room');
+        });
+
+        test('matches room name with unicode characters', () => {
+            const encoded = '/multi/' + encodeURIComponent('대전방');
+            const match = encoded.match(pattern);
+            expect(match).not.toBeNull();
+            expect(decodeURIComponent(match![1])).toBe('대전방');
+        });
+
+        test('does not match bare /multi/', () => {
+            const match = '/multi/'.match(pattern);
+            expect(match).toBeNull();
+        });
+
+        test('does not match /multi without trailing slash', () => {
+            const match = '/multi'.match(pattern);
+            expect(match).toBeNull();
+        });
+
+        test('does not match /n-multi/ path', () => {
+            const match = '/n-multi/MyRoom'.match(pattern);
+            expect(match).toBeNull();
+        });
+
+        test('does not match root path /', () => {
+            const match = '/'.match(pattern);
+            expect(match).toBeNull();
+        });
+    });
+
+    describe('URL Pattern Priority', () => {
+        const nMultiPattern = /^\/n-multi\/(.+)$/;
+        const multiPattern = /^\/multi\/(.+)$/;
+
+        test('/n-multi path only matches n-multi pattern', () => {
+            const path = '/n-multi/TestRoom';
+            expect(path.match(nMultiPattern)).not.toBeNull();
+            expect(path.match(multiPattern)).toBeNull();
+        });
+
+        test('/multi path only matches multi pattern', () => {
+            const path = '/multi/TestRoom';
+            expect(path.match(nMultiPattern)).toBeNull();
+            expect(path.match(multiPattern)).not.toBeNull();
+        });
+
+        test('root path matches neither pattern', () => {
+            const path = '/';
+            expect(path.match(nMultiPattern)).toBeNull();
+            expect(path.match(multiPattern)).toBeNull();
+        });
+    });
+
+    describe('Room Name Encoding/Decoding Roundtrip', () => {
+        const testNames = [
+            'SimpleRoom',
+            'Room With Spaces',
+            'room#123',
+            'room/sub/path',
+            '특수문자방',
+            'Room & Friends',
+            'Room=100%',
+            'emoji🎮room',
+        ];
+
+        test.each(testNames)('roundtrip preserves room name: %s', (name) => {
+            const encoded = encodeURIComponent(name);
+            const decoded = decodeURIComponent(encoded);
+            expect(decoded).toBe(name);
+        });
+
+        test.each(testNames)('URL construction and extraction works for: %s', (name) => {
+            const url = '/n-multi/' + encodeURIComponent(name);
+            const match = url.match(/^\/n-multi\/(.+)$/);
+            expect(match).not.toBeNull();
+            expect(decodeURIComponent(match![1])).toBe(name);
+        });
+    });
+
+    describe('history.replaceState URL Management', () => {
+        let originalReplaceState: typeof history.replaceState;
+
+        beforeEach(() => {
+            originalReplaceState = history.replaceState;
+            history.replaceState = jest.fn();
+        });
+
+        afterEach(() => {
+            history.replaceState = originalReplaceState;
+        });
+
+        test('sets n-multi URL with room name', () => {
+            const roomName = 'TestRoom';
+            history.replaceState(null, '', '/n-multi/' + encodeURIComponent(roomName));
+
+            expect(history.replaceState).toHaveBeenCalledWith(null, '', '/n-multi/TestRoom');
+        });
+
+        test('sets multi URL with room name', () => {
+            const roomName = 'TestRoom';
+            history.replaceState(null, '', '/multi/' + encodeURIComponent(roomName));
+
+            expect(history.replaceState).toHaveBeenCalledWith(null, '', '/multi/TestRoom');
+        });
+
+        test('resets to root on exit', () => {
+            history.replaceState(null, '', '/');
+
+            expect(history.replaceState).toHaveBeenCalledWith(null, '', '/');
+        });
+
+        test('encodes special characters in URL', () => {
+            const roomName = 'Room With Spaces';
+            history.replaceState(null, '', '/n-multi/' + encodeURIComponent(roomName));
+
+            expect(history.replaceState).toHaveBeenCalledWith(null, '', '/n-multi/Room%20With%20Spaces');
+        });
+
+        test('encodes Korean characters in URL', () => {
+            const roomName = '테스트방';
+            history.replaceState(null, '', '/multi/' + encodeURIComponent(roomName));
+
+            expect(history.replaceState).toHaveBeenCalledWith(
+                null, '', '/multi/' + encodeURIComponent('테스트방')
+            );
+        });
+    });
+
+    describe('Lobby URL Prefix Configuration', () => {
+        test('multi config uses /multi prefix', () => {
+            const urlPrefix = '/multi';
+            const roomName = 'LobbyRoom';
+            const expectedUrl = '/multi/LobbyRoom';
+
+            expect(urlPrefix + '/' + encodeURIComponent(roomName)).toBe(expectedUrl);
+        });
+
+        test('n-multi config uses /n-multi prefix', () => {
+            const urlPrefix = '/n-multi';
+            const roomName = 'LobbyRoom';
+            const expectedUrl = '/n-multi/LobbyRoom';
+
+            expect(urlPrefix + '/' + encodeURIComponent(roomName)).toBe(expectedUrl);
+        });
+
+        test('URL is constructed from response roomName', () => {
+            // Simulates lobby roomJoined handler
+            const urlPrefix = '/n-multi';
+            const data = { roomId: 'abc-123', roomName: 'My Room' };
+
+            const url = urlPrefix + '/' + encodeURIComponent(data.roomName);
+            expect(url).toBe('/n-multi/My%20Room');
+        });
+    });
+
+    describe('Scene Data roomName Propagation', () => {
+        test('1v1 scene data includes roomName', () => {
+            const sceneData = {
+                mode: 'multi',
+                socket: {},
+                roomId: 'room-123',
+                isHost: true,
+                roomName: 'Test Room'
+            };
+
+            expect(sceneData.roomName).toBe('Test Room');
+        });
+
+        test('n-multi scene data includes roomName', () => {
+            const sceneData = {
+                socket: {},
+                roomId: 'room-123',
+                playerId: 'player-1',
+                playerName: 'Player1',
+                initialPlayers: {},
+                roomName: 'Test Room'
+            };
+
+            expect(sceneData.roomName).toBe('Test Room');
+        });
+
+        test('restart data preserves roomName for 1v1', () => {
+            const originalData = { mode: 'multi', roomId: 'room-1', roomName: 'Persistent Room' };
+            const restartData = { mode: 'multi', socket: {}, roomId: originalData.roomId, roomName: originalData.roomName };
+
+            expect(restartData.roomName).toBe('Persistent Room');
+        });
+
+        test('restart data preserves roomName for n-multi', () => {
+            const originalRoomName = 'NMulti Room';
+            const restartData = {
+                socket: {},
+                roomId: 'room-1',
+                roomName: originalRoomName,
+                playerId: 'p1',
+                playerName: 'Player1',
+                initialPlayers: {}
+            };
+
+            expect(restartData.roomName).toBe(originalRoomName);
+        });
+
+        test('single player mode has no roomName', () => {
+            const sceneData = { mode: 'single' };
+            expect((sceneData as any).roomName).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
This PR adds support for joining game rooms directly via URL patterns, allowing players to share room links and join games without going through the lobby. It also improves error handling and state management across multiplayer scenes.

## Key Changes

**Client-side (MenuScene)**
- Renamed `joinRoomByUrl()` to `joinNMultiRoomByUrl()` for clarity
- Added new `joinMultiRoomByUrl()` method to handle `/multi/{roomName}` URL pattern
- Added URL pattern detection for both `/n-multi/{roomName}` and `/multi/{roomName}` routes
- Improved error handling with proper history state reset and UI recreation on connection failures
- Added `connect_error` event handler for both room join methods

**Client-side (PlayScene & NMultiPlayScene)**
- Added `roomName` property to track the room name for URL management
- Updated scene restart calls to preserve `roomName` parameter
- Added history state reset when leaving multiplayer games or on opponent disconnect

**Client-side (LobbyScene)**
- Added `urlPrefix` configuration to support different URL patterns per game mode
- Implemented automatic URL update when joining a room via `roomJoined` event
- Room names are properly encoded in URLs using `encodeURIComponent()`

**Server-side (index.js)**
- Added new `join_or_create` socket event handler that:
  - Searches for existing waiting rooms by name
  - Joins as player 2 if a waiting room exists
  - Creates a new room if no waiting room is found
- Updated all `room_joined` emissions to include `roomName` in the response
- Added `roomName` to n-multi room join responses for consistency

## Implementation Details
- Room names are URL-encoded/decoded to handle special characters safely
- History state is properly managed to prevent back button issues
- The `join_or_create` logic ensures deterministic room joining: first player creates, second player joins
- Error states properly clean up resources and reset URL history before returning to menu

https://claude.ai/code/session_013DJXKcCcBUnuBjo1dTjtS1