### PR TITLE
feat: responsive layout for mobile and mini-field improvements

### DIFF
--- a/src/tetris/engine.ts
+++ b/src/tetris/engine.ts
@@ -147,7 +147,7 @@ export class Engine {
         }
 
         // Update indicator.
-        if (result.actionName) this.levelIndicator.setAction(result.actionName);
+        this.levelIndicator.setAction(result.actionName);
         this.levelIndicator.setCombo(result.combo);
         // this.levelIndicator.setLevel(result.level);
         // this.levelIndicator.setLine(this.scoreSystem.getClearedLines(), this.scoreSystem.getNextLevelRequireClearedLines());

--- a/src/tetris/input/inputManager.ts
+++ b/src/tetris/input/inputManager.ts
@@ -127,18 +127,11 @@ export class InputManager {
             this.emitInput('softDrop', InputState.RELEASE);
 
             if (this.isTap) {
-                // Check Rotation
-                // We use scene.scale.width to determine 'center' of screen relative to camera if needed,
-                // but PlayScene uses logical GAME_WIDTH.
-                // For now, we assume standard landscape center.
-                // Ideally, we should pass the click region.
-                // But let's assume worldX is correct.
+                // Check Rotation - use world-space center for correct comparison with pointer.worldX
+                const cam = this.scene.cameras.main;
+                const centerWidth = cam.scrollX + (cam.width / cam.zoom) / 2;
 
-                // TODO: Improve this hardcoded width check if possible.
-                // Assuming logical width is consistent with PlayScene logic.
-                const centerWidth = this.scene.cameras.main.width / 2; // approximate
-
-                if (pointer.worldX < centerWidth) { // approximate center
+                if (pointer.worldX < centerWidth) {
                     this.emitInput('anticlockwise', InputState.PRESS);
                     this.scene.time.delayedCall(100, () => this.emitInput('anticlockwise', InputState.RELEASE));
                 } else {

--- a/src/tetris/objects/levelIndicator.ts
+++ b/src/tetris/objects/levelIndicator.ts
@@ -9,7 +9,7 @@ import {
 
 const BLOCK_SIZE = getBlockSize();
 
-// Layout constants
+// Layout constants (standard vertical mode)
 const BG_WIDTH = BLOCK_SIZE * 5;
 const BG_HEIGHT = BLOCK_SIZE * 16.5;
 const PADDING_LEFT = BLOCK_SIZE * 0.5;
@@ -19,8 +19,17 @@ const HEADER_ROW_HEIGHT = BLOCK_SIZE;
 const VALUE_ROW_HEIGHT = BLOCK_SIZE * 1.5;
 const TEMP_TEXT_DURATION = 3000;
 
+// Compact horizontal mode constants
+const COMPACT_WIDTH = BLOCK_SIZE * 10;
+const COMPACT_HEIGHT = BLOCK_SIZE * 3;
+
+export interface LevelIndicatorOptions {
+    compact?: boolean;
+}
+
 export class LevelIndicator extends ObjectBase {
     public container: Phaser.GameObjects.Container;
+    private compact: boolean;
 
     // Large value displays
     private scoreValueText: Phaser.GameObjects.Text;
@@ -42,10 +51,74 @@ export class LevelIndicator extends ObjectBase {
     private comboText: Phaser.GameObjects.Text;
     private comboTextShowEvent: Phaser.Time.TimerEvent;
 
-    constructor(scene: Phaser.Scene, x: number, y: number) {
+    constructor(scene: Phaser.Scene, x: number, y: number, options?: LevelIndicatorOptions) {
         super(scene);
+        this.compact = options?.compact ?? false;
         this.container = scene.add.container(x, y);
-        this.createUI();
+        if (this.compact) {
+            this.createCompactUI();
+        } else {
+            this.createUI();
+        }
+    }
+
+    private createCompactUI() {
+        const bg = this.scene.add.graphics();
+        drawPanelBackground(bg, COMPACT_WIDTH, COMPACT_HEIGHT);
+        this.container.add(bg);
+
+        const pad = BLOCK_SIZE * 0.4;
+        const midY = BLOCK_SIZE * 0.3;
+        const bottomY = BLOCK_SIZE * 1.6;
+        const halfW = COMPACT_WIDTH / 2;
+
+        // Row 1: SCORE (large, left-aligned) + TIME (right-aligned)
+        createStyledText(this.scene, this.container, pad, midY, 'SCORE', TextStyles.label, 3);
+        this.scoreValueText = createStyledText(
+            this.scene, this.container, pad + BLOCK_SIZE * 2.2, midY, '0',
+            { ...TextStyles.valueLarge, fontSize: `${BLOCK_SIZE * 0.7}px` }, 3
+        );
+        this.timeValueText = createStyledText(
+            this.scene, this.container, COMPACT_WIDTH - pad, midY, '00:00',
+            { ...TextStyles.valueSmall, fontSize: `${BLOCK_SIZE * 0.55}px` }, 3
+        );
+        this.timeValueText.setOrigin(1, 0);
+
+        // Row 2: LV:x   LN:x
+        const colW = (COMPACT_WIDTH - pad * 2) / 3;
+        const makeCompactStat = (label: string, colIdx: number) => {
+            const lx = pad + colW * colIdx;
+            createStyledText(this.scene, this.container, lx, bottomY, label,
+                { ...TextStyles.label, fontSize: `${BLOCK_SIZE * 0.4}px` }, 2);
+            const vt = createStyledText(this.scene, this.container, lx + BLOCK_SIZE * 1.2, bottomY, '0',
+                { ...TextStyles.valueSmall, fontSize: `${BLOCK_SIZE * 0.5}px` }, 2);
+            return vt;
+        };
+
+        this.levelValueText = makeCompactStat('LV', 0);
+        this.linesValueText = makeCompactStat('LN', 1);
+        this.goalValueText = makeCompactStat('GL', 2);
+
+        // Hidden stats (tracked internally but not shown)
+        const hiddenStyle = { ...TextStyles.valueSmall, fontSize: '1px' };
+        this.tetrisesValueText = this.scene.add.text(-9999, -9999, '0', hiddenStyle);
+        this.tSpinsValueText = this.scene.add.text(-9999, -9999, '0', hiddenStyle);
+        this.combosValueText = this.scene.add.text(-9999, -9999, '0', hiddenStyle);
+        this.tpmValueText = this.scene.add.text(-9999, -9999, '0', hiddenStyle);
+        this.lpmValueText = this.scene.add.text(-9999, -9999, '0', hiddenStyle);
+
+        // Action/Combo text - overlaid centered above this container
+        this.actionText = createStyledText(
+            this.scene, this.container,
+            halfW, -BLOCK_SIZE * 1.2, '', TextStyles.action,
+        );
+        this.actionText.setOrigin(0.5, 0);
+
+        this.comboText = createStyledText(
+            this.scene, this.container,
+            halfW, -BLOCK_SIZE * 0.5, '', TextStyles.combo,
+        );
+        this.comboText.setOrigin(0.5, 0);
     }
 
     private createUI() {
@@ -140,7 +213,7 @@ export class LevelIndicator extends ObjectBase {
     setLine(cleared, nextGoal) { }
     setScore(score: number) { }
 
-    setAction(action?: string) {
+    setAction(action?: string | null) {
         this.actionTextShowEvent?.destroy();
         this.actionTextShowEvent = null;
 

--- a/src/tetris/objects/miniPlayField.ts
+++ b/src/tetris/objects/miniPlayField.ts
@@ -23,6 +23,7 @@ export class MiniPlayField {
     private blockContainer: Phaser.GameObjects.Container;
     private dimGraphics: Phaser.GameObjects.Graphics;
     private nameText: Phaser.GameObjects.Text;
+    private rankText: Phaser.GameObjects.Text;
     private scoreText: Phaser.GameObjects.Text;
     private gameOverText: Phaser.GameObjects.Text;
     private gameOverScoreText: Phaser.GameObjects.Text;
@@ -56,11 +57,17 @@ export class MiniPlayField {
         this.dimGraphics.setVisible(false);
         this.container.add(this.dimGraphics);
 
-        // Info texts
+        // Name text (above field)
         this.nameText = this.createText(playerName, { fontSize: '12px', color: '#ffffff' }, 3);
         this.nameText.setOrigin(0, 1);
 
+        // Rank text (below field, left-aligned)
+        this.rankText = this.createText('', { fontSize: '10px', color: '#ffbe0b' }, 2);
+        this.rankText.setOrigin(0, 0);
+
+        // Score text (below field, right-aligned)
         this.scoreText = this.createText('0', { fontSize: '10px', color: '#ffffff' }, 2);
+        this.scoreText.setOrigin(1, 0);
 
         // Game over overlay texts (hidden by default)
         this.gameOverText = this.createText('GAME OVER', { fontSize: '12px', color: '#ff0000', align: 'center' }, 3);
@@ -93,6 +100,10 @@ export class MiniPlayField {
         this.updateGameOverOverlay();
     }
 
+    updateRank(rank: number) {
+        this.rankText.setText(`#${rank}`);
+    }
+
     setPosition(x: number, y: number) {
         this.container.setPosition(x, y);
     }
@@ -102,14 +113,20 @@ export class MiniPlayField {
         const fieldWidth = cellSize * COLS;
         const fieldHeight = cellSize * ROWS;
 
-        const fontSize = Math.max(8, Math.floor(cellSize * 2.5));
-        const scoreFontSize = Math.max(6, Math.floor(cellSize * 2));
-
-        this.nameText.setFontSize(fontSize);
+        // Name: scale with cellSize but cap to prevent overflow
+        const nameFontSize = Math.max(8, Math.min(Math.floor(cellSize * 2), 18));
+        this.nameText.setFontSize(nameFontSize);
         this.nameText.setPosition(0, -2);
+        // Crop name text to fieldWidth to prevent horizontal overflow
+        this.nameText.setCrop(0, 0, fieldWidth, nameFontSize * 2);
 
-        this.scoreText.setFontSize(scoreFontSize);
-        this.scoreText.setPosition(0, fieldHeight + 2);
+        // Bottom info row: rank (left) + score (right)
+        const infoFontSize = Math.max(6, Math.min(Math.floor(cellSize * 1.8), 14));
+        this.rankText.setFontSize(infoFontSize);
+        this.rankText.setPosition(0, fieldHeight + 2);
+
+        this.scoreText.setFontSize(infoFontSize);
+        this.scoreText.setPosition(fieldWidth, fieldHeight + 2);
 
         // Game over text sizing
         const goFontSize = Math.max(8, Math.floor(cellSize * 2));

--- a/src/tetris/scenes/baseScene.ts
+++ b/src/tetris/scenes/baseScene.ts
@@ -1,25 +1,28 @@
 
+export type LayoutMode = 'desktop' | 'mobile-portrait' | 'mobile-landscape';
+
 export abstract class BaseScene extends Phaser.Scene {
     // Logical base resolution
     protected GAME_WIDTH: number = 1920;
     protected GAME_HEIGHT: number = 1080;
     protected isMobile: boolean = false;
+    protected layoutMode: LayoutMode = 'desktop';
 
     constructor(config: string | Phaser.Types.Scenes.SettingsConfig) {
         super(config);
     }
 
+    protected getLayoutMode(): LayoutMode {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        const isMobile = Math.min(w, h) < 768;
+        if (!isMobile) return 'desktop';
+        return w < h ? 'mobile-portrait' : 'mobile-landscape';
+    }
+
     protected handleResolution(): void {
-        // Detect Mobile Portrait
-        if (window.innerWidth < window.innerHeight) {
-            this.GAME_WIDTH = 800;
-            this.GAME_HEIGHT = 1200;
-            this.isMobile = true;
-        } else {
-            this.GAME_WIDTH = 1920;
-            this.GAME_HEIGHT = 1080;
-            this.isMobile = false;
-        }
+        this.layoutMode = this.getLayoutMode();
+        this.isMobile = this.layoutMode !== 'desktop';
     }
 
     protected backgroundGraphics: Phaser.GameObjects.Graphics;

--- a/src/tetris/scenes/nMultiPlayScene.ts
+++ b/src/tetris/scenes/nMultiPlayScene.ts
@@ -6,10 +6,9 @@ import { InputManager } from "../input/inputManager";
 import { InGameMenu } from "../ui/inGameMenu";
 import { BaseScene } from "./baseScene";
 import { MiniPlayField } from "../objects/miniPlayField";
-import { LeaderboardPanel, LeaderboardEntry } from "../ui/leaderboardPanel";
 import { BoardCodec } from "../net/boardCodec";
 import { BotManager } from "../logic/botManager";
-import { createGameLayout, calcNMultiPlayerPosition } from "../ui/gameLayout";
+import { createGameLayout, calcNMultiPlayerPosition, calcNMultiSceneDimensions, calcPortraitPosition } from "../ui/gameLayout";
 
 const BLOCK_SIZE = getBlockSize();
 
@@ -35,9 +34,8 @@ export class NMultiPlayScene extends BaseScene {
     // Opponents
     private miniFields: Map<string, MiniPlayField> = new Map();
     private opponentContainer: Phaser.GameObjects.Container;
-    private leaderboard: LeaderboardPanel;
 
-    // Snapshot data for leaderboard
+    // Snapshot data for rank computation
     private snapshotPlayers: Record<string, any> = {};
 
     constructor() {
@@ -47,8 +45,9 @@ export class NMultiPlayScene extends BaseScene {
     init(data: any): void {
         this.handleResolution();
 
-        this.GAME_WIDTH = BLOCK_SIZE * 36;
-        this.GAME_HEIGHT = BLOCK_SIZE * 22;
+        const dims = calcNMultiSceneDimensions(this.layoutMode);
+        this.GAME_WIDTH = dims.width;
+        this.GAME_HEIGHT = dims.height;
 
         this.socket = data.socket;
         this.roomId = data.roomId;
@@ -104,7 +103,6 @@ export class NMultiPlayScene extends BaseScene {
         });
 
         this.opponentContainer = this.add.container(0, 0);
-        this.leaderboard = new LeaderboardPanel(this.playerId);
 
         this.setupSocketEvents();
 
@@ -176,7 +174,7 @@ export class NMultiPlayScene extends BaseScene {
                 }
             }
 
-            this.updateLeaderboard();
+            this.updateRanks();
         });
 
         this.socket.on('nmulti_player_joined', (data: any) => {
@@ -193,7 +191,7 @@ export class NMultiPlayScene extends BaseScene {
                 this.miniFields.delete(data.playerId);
                 delete this.snapshotPlayers[data.playerId];
                 this.relayoutOpponents();
-                this.updateLeaderboard();
+                this.updateRanks();
             }
         });
 
@@ -216,26 +214,39 @@ export class NMultiPlayScene extends BaseScene {
         const count = this.miniFields.size;
         if (count === 0) return;
 
-        // Opponent area: right portion after the player area
-        const areaX = BLOCK_SIZE * 23.5;
-        const areaY = BLOCK_SIZE * 1;
-        const areaWidth = this.GAME_WIDTH - areaX - BLOCK_SIZE * 0.5;
-        const areaHeight = this.GAME_HEIGHT - BLOCK_SIZE * 2;
-        const textHeight = 24;
+        const isPortrait = this.layoutMode === 'mobile-portrait';
+
+        // Opponent area dimensions
+        let areaX: number, areaY: number, areaWidth: number, areaHeight: number;
+        if (isPortrait) {
+            // Below player area in portrait
+            areaX = BLOCK_SIZE * 0.5;
+            areaY = BLOCK_SIZE * 28.5; // Below playfield + compact stats
+            areaWidth = this.GAME_WIDTH - BLOCK_SIZE;
+            areaHeight = this.GAME_HEIGHT - areaY - BLOCK_SIZE * 0.5;
+        } else {
+            // Right of player area in desktop
+            areaX = BLOCK_SIZE * 23.5;
+            areaY = BLOCK_SIZE * 1;
+            areaWidth = this.GAME_WIDTH - areaX - BLOCK_SIZE * 0.5;
+            areaHeight = this.GAME_HEIGHT - BLOCK_SIZE * 2;
+        }
+        // Height factor: 20 field rows + 2 name + 2 info = 24 cell-size units
+        const TOTAL_ROWS = 24;
 
         // Find optimal grid layout (maximize mini field size)
         let bestCols = 1;
-        let bestFieldWidth = 0;
+        let bestCellSize = 1;
 
         for (let cols = 1; cols <= count; cols++) {
             const rows = Math.ceil(count / cols);
             const cellWidth = areaWidth / cols;
             const cellHeight = areaHeight / rows;
-            const fieldWidthFromWidth = cellWidth - 4;
-            const fieldWidthFromHeight = (cellHeight - textHeight - 4) * 0.5;
-            const fieldWidth = Math.min(fieldWidthFromWidth, fieldWidthFromHeight);
-            if (fieldWidth > bestFieldWidth) {
-                bestFieldWidth = fieldWidth;
+            const cellSizeFromWidth = (cellWidth - 4) / CONST.PLAY_FIELD.COL_COUNT;
+            const cellSizeFromHeight = (cellHeight - 8) / TOTAL_ROWS;
+            const cellSize = Math.min(cellSizeFromWidth, cellSizeFromHeight);
+            if (cellSize > bestCellSize) {
+                bestCellSize = cellSize;
                 bestCols = cols;
             }
         }
@@ -243,43 +254,49 @@ export class NMultiPlayScene extends BaseScene {
         const bestRows = Math.ceil(count / bestCols);
         const cellWidth = areaWidth / bestCols;
         const cellHeight = areaHeight / bestRows;
-        const cellSize = Math.max(1, bestFieldWidth / 10);
+        const cellSize = Math.max(1, bestCellSize);
+
+        // Name height matches the capped font size in MiniPlayField.resize()
+        const nameHeight = Math.max(8, Math.min(Math.floor(cellSize * 2), 18)) + 4;
 
         let idx = 0;
         for (const [, mini] of this.miniFields) {
             const col = idx % bestCols;
             const row = Math.floor(idx / bestCols);
-            mini.setPosition(areaX + col * cellWidth + 2, areaY + row * cellHeight + textHeight);
+            mini.setPosition(areaX + col * cellWidth + 2, areaY + row * cellHeight + nameHeight);
             mini.resize(cellSize);
             idx++;
         }
     }
 
-    private updateLeaderboard() {
-        const entries: LeaderboardEntry[] = [];
+    private updateRanks() {
+        const entries: { playerId: string; score: number }[] = [];
 
         // Add self
         if (this.engine) {
             const stats = this.engine.getStats();
-            entries.push({
-                playerId: this.playerId,
-                name: this.playerName,
-                score: stats.score,
-                isAlive: !this.isGameEnded
-            });
+            entries.push({ playerId: this.playerId, score: stats.score });
         }
 
         // Add opponents from snapshot
         for (const [id, p] of Object.entries(this.snapshotPlayers) as [string, any][]) {
-            entries.push({
-                playerId: id,
-                name: p.name,
-                score: p.score || 0,
-                isAlive: p.isAlive !== false
-            });
+            entries.push({ playerId: id, score: p.score || 0 });
         }
 
-        this.leaderboard.update(entries);
+        // Sort by score descending
+        entries.sort((a, b) => b.score - a.score);
+
+        // Build rank map
+        const rankMap = new Map<string, number>();
+        entries.forEach((e, i) => rankMap.set(e.playerId, i + 1));
+
+        // Update mini fields with their rank
+        for (const [id, mini] of this.miniFields) {
+            const rank = rankMap.get(id);
+            if (rank !== undefined) {
+                mini.updateRank(rank);
+            }
+        }
     }
 
     private shutdown() {
@@ -295,9 +312,6 @@ export class NMultiPlayScene extends BaseScene {
         }
         if (this.inGameMenu) {
             this.inGameMenu.destroy();
-        }
-        if (this.leaderboard) {
-            this.leaderboard.destroy();
         }
         for (const [, mini] of this.miniFields) {
             mini.destroy();
@@ -368,7 +382,10 @@ export class NMultiPlayScene extends BaseScene {
         this.isGameRunning = true;
         this.inputManager.isEnabled = true;
 
-        const pos = calcNMultiPlayerPosition(this.GAME_HEIGHT);
+        const isPortrait = this.layoutMode === 'mobile-portrait';
+        const pos = isPortrait
+            ? calcPortraitPosition(this.GAME_WIDTH)
+            : calcNMultiPlayerPosition(this.GAME_HEIGHT);
 
         const layout = createGameLayout({
             scene: this,
@@ -376,6 +393,7 @@ export class NMultiPlayScene extends BaseScene {
             fieldY: pos.y,
             onHoldInput: (dir, state) => this.onInput(dir, state),
             isInputBlocked: () => !this.isGameRunning || this.isPause || this.inGameMenu.isMenuOpen || this.isGameEnded,
+            layoutMode: this.layoutMode,
         });
 
         this.playField = layout.playField;

--- a/src/tetris/scenes/playScene.ts
+++ b/src/tetris/scenes/playScene.ts
@@ -16,6 +16,8 @@ import {
     createGameLayout,
     calcSinglePlayerPosition,
     calcMultiPlayerPosition,
+    calcPlaySceneDimensions,
+    calcPortraitPosition,
 } from "../ui/gameLayout";
 
 const BLOCK_SIZE = getBlockSize();
@@ -54,9 +56,6 @@ export class PlayScene extends BaseScene {
     init(data: any): void {
         this.handleResolution();
 
-        this.GAME_WIDTH = BLOCK_SIZE * 22;
-        this.GAME_HEIGHT = BLOCK_SIZE * 22;
-
         this.mode = data.mode || 'single';
         this.roomName = data.roomName;
         this.botLevel = data.botLevel || 0;
@@ -64,6 +63,10 @@ export class PlayScene extends BaseScene {
             this.socket = data.socket;
             this.roomId = data.roomId;
         }
+
+        const dims = calcPlaySceneDimensions(this.layoutMode, this.mode);
+        this.GAME_WIDTH = dims.width;
+        this.GAME_HEIGHT = dims.height;
 
         this.isPause = false;
         this.isGameRunning = false;
@@ -241,23 +244,30 @@ export class PlayScene extends BaseScene {
         this.isGameRunning = true;
         this.inputManager.isEnabled = true;
 
+        const isPortrait = this.layoutMode === 'mobile-portrait';
         const currentMainScale = (this.mode === 'single') ? this.MAIN_SCALE : 1;
         const currentSideScale = (this.mode === 'single') ? this.SIDE_SCALE : 1;
 
-        // Calculate play field position based on mode
-        const pos = (this.mode === 'single')
-            ? calcSinglePlayerPosition(this.GAME_WIDTH, this.GAME_HEIGHT, currentMainScale)
-            : calcMultiPlayerPosition(this.GAME_WIDTH, this.GAME_HEIGHT);
+        // Calculate play field position based on mode and layout
+        let pos: { x: number; y: number };
+        if (isPortrait) {
+            pos = calcPortraitPosition(this.GAME_WIDTH);
+        } else if (this.mode === 'single') {
+            pos = calcSinglePlayerPosition(this.GAME_WIDTH, this.GAME_HEIGHT, currentMainScale);
+        } else {
+            pos = calcMultiPlayerPosition(this.GAME_WIDTH, this.GAME_HEIGHT);
+        }
 
         // Create standard game layout
         const layout = createGameLayout({
             scene: this,
             fieldX: pos.x,
             fieldY: pos.y,
-            mainScale: currentMainScale,
-            sideScale: currentSideScale,
+            mainScale: isPortrait ? 1 : currentMainScale,
+            sideScale: isPortrait ? 1 : currentSideScale,
             onHoldInput: (dir, state) => this.onInput(dir, state),
             isInputBlocked: () => !this.isGameRunning || this.isPause || this.inGameMenu.isMenuOpen || this.isGameEnded,
+            layoutMode: this.layoutMode,
         });
 
         this.playField = layout.playField;
@@ -278,7 +288,7 @@ export class PlayScene extends BaseScene {
         });
 
         this.engine.start();
-        this.inputManager.setDragThresholdScale(currentMainScale);
+        this.inputManager.setDragThresholdScale(isPortrait ? 1 : currentMainScale);
 
         if (this.botLevel > 0) {
             this.botManager = new BotManager(this.engine, this.playField, this.botLevel);
@@ -289,10 +299,20 @@ export class PlayScene extends BaseScene {
         if (this.mode === 'multi') {
             const rawPlayFieldWidth = BLOCK_SIZE * CONST.PLAY_FIELD.COL_COUNT;
             const rawPlayFieldHeight = BLOCK_SIZE * CONST.PLAY_FIELD.ROW_COUNT;
-            const p2X = (this.GAME_WIDTH * 0.75) - (rawPlayFieldWidth / 2);
-            const p2Y = (this.GAME_HEIGHT - rawPlayFieldHeight) / 2;
-            this.opponentPlayField = new PlayField(this, p2X, p2Y, rawPlayFieldWidth, rawPlayFieldHeight);
-            this.add.text(p2X, p2Y - 30, 'Opponent', { fontSize: '20px', color: '#ffffff' });
+            if (isPortrait) {
+                // Opponent below player in portrait mode (scaled down)
+                const opScale = 0.4;
+                const opX = (this.GAME_WIDTH - rawPlayFieldWidth * opScale) / 2;
+                const opY = pos.y + rawPlayFieldHeight + BLOCK_SIZE * 4.5; // below compact stats
+                this.opponentPlayField = new PlayField(this, opX, opY, rawPlayFieldWidth, rawPlayFieldHeight);
+                this.opponentPlayField.setScale(opScale);
+                this.add.text(opX, opY - 20, 'Opponent', { fontSize: '16px', color: '#ffffff' });
+            } else {
+                const p2X = (this.GAME_WIDTH * 0.75) - (rawPlayFieldWidth / 2);
+                const p2Y = (this.GAME_HEIGHT - rawPlayFieldHeight) / 2;
+                this.opponentPlayField = new PlayField(this, p2X, p2Y, rawPlayFieldWidth, rawPlayFieldHeight);
+                this.add.text(p2X, p2Y - 30, 'Opponent', { fontSize: '20px', color: '#ffffff' });
+            }
         }
     }
 

--- a/src/tetris/ui/gameLayout.ts
+++ b/src/tetris/ui/gameLayout.ts
@@ -4,6 +4,7 @@ import { TetrominoBox } from "../objects/tetrominoBox";
 import { TetrominoBoxQueue } from "../objects/tetrominoBoxQueue";
 import { LevelIndicator } from "../objects/levelIndicator";
 import { Engine } from "../engine";
+import { LayoutMode } from "../scenes/baseScene";
 
 const BLOCK_SIZE = getBlockSize();
 
@@ -12,6 +13,11 @@ const GAP = BLOCK_SIZE * 0.5;
 const HOLD_WIDTH = BLOCK_SIZE * 5;
 const HOLD_HEIGHT = BLOCK_SIZE * 3;
 const QUEUE_SIZE = 6;
+
+// Mobile portrait constants
+const MOBILE_HOLD_WIDTH = BLOCK_SIZE * 4;
+const MOBILE_HOLD_HEIGHT = BLOCK_SIZE * 3;
+const MOBILE_QUEUE_SIZE = 1;
 
 export interface GameLayoutResult {
     holdBox: TetrominoBox;
@@ -35,7 +41,36 @@ export interface GameLayoutOptions {
     onHoldInput: (direction: string, state: InputState) => void;
     /** Guard function to check if input should be accepted */
     isInputBlocked: () => boolean;
+    /** Layout mode for responsive positioning */
+    layoutMode?: LayoutMode;
 }
+
+// ─── Dimension Calculators ──────────────────────────────────────────
+
+/**
+ * Calculate scene dimensions based on layout mode for PlayScene.
+ */
+export function calcPlaySceneDimensions(layoutMode: LayoutMode, mode: string): { width: number; height: number } {
+    if (layoutMode === 'mobile-portrait') {
+        if (mode === 'multi') {
+            return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 35 };
+        }
+        return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 27 };
+    }
+    return { width: BLOCK_SIZE * 22, height: BLOCK_SIZE * 22 };
+}
+
+/**
+ * Calculate scene dimensions based on layout mode for NMultiPlayScene.
+ */
+export function calcNMultiSceneDimensions(layoutMode: LayoutMode): { width: number; height: number } {
+    if (layoutMode === 'mobile-portrait') {
+        return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 35 };
+    }
+    return { width: BLOCK_SIZE * 36, height: BLOCK_SIZE * 22 };
+}
+
+// ─── Position Calculators ───────────────────────────────────────────
 
 /**
  * Calculate the play field position for single-player mode (centered).
@@ -75,10 +110,32 @@ export function calcNMultiPlayerPosition(gameHeight: number, playerAreaBlocks: n
 }
 
 /**
+ * Portrait position: playfield centered horizontally, below hold+next row.
+ */
+export function calcPortraitPosition(gameWidth: number): { x: number; y: number } {
+    const rawWidth = BLOCK_SIZE * CONST.PLAY_FIELD.COL_COUNT;
+    return {
+        x: (gameWidth - rawWidth) / 2,
+        y: BLOCK_SIZE * 4.5,  // Below hold+next row (3 blocks hold + 1 header + 0.5 gap)
+    };
+}
+
+// ─── Layout Factory ─────────────────────────────────────────────────
+
+/**
  * Create the standard game layout: Hold box, Level Indicator, Queue, PlayField, Engine.
- * Eliminates the duplicate layout code between PlayScene and NMultiPlayScene.
+ * Supports desktop and mobile-portrait layouts.
  */
 export function createGameLayout(options: GameLayoutOptions): GameLayoutResult {
+    const layoutMode = options.layoutMode ?? 'desktop';
+
+    if (layoutMode === 'mobile-portrait') {
+        return createPortraitLayout(options);
+    }
+    return createDesktopLayout(options);
+}
+
+function createDesktopLayout(options: GameLayoutOptions): GameLayoutResult {
     const { scene, fieldX, fieldY, onHoldInput, isInputBlocked } = options;
     const mainScale = options.mainScale ?? 1;
     const sideScale = options.sideScale ?? 1;
@@ -116,6 +173,45 @@ export function createGameLayout(options: GameLayoutOptions): GameLayoutResult {
     // Play Field
     const playField = new PlayField(scene, fieldX, fieldY, rawPlayFieldWidth, rawPlayFieldHeight);
     playField.setScale(mainScale);
+
+    // Engine
+    const engine = new Engine(playField, holdBox, tetrominoQueue, levelIndicator);
+
+    return { holdBox, levelIndicator, tetrominoQueue, playField, engine };
+}
+
+function createPortraitLayout(options: GameLayoutOptions): GameLayoutResult {
+    const { scene, fieldX, fieldY, onHoldInput, isInputBlocked } = options;
+
+    const rawPlayFieldWidth = BLOCK_SIZE * CONST.PLAY_FIELD.COL_COUNT;
+    const rawPlayFieldHeight = BLOCK_SIZE * CONST.PLAY_FIELD.ROW_COUNT;
+
+    // Hold Box (above-left of play field)
+    const holdX = fieldX;
+    const holdY = fieldY - MOBILE_HOLD_HEIGHT - GAP - BLOCK_SIZE * 0.6; // space for header text
+    const holdBox = new TetrominoBox(scene, holdX, holdY, MOBILE_HOLD_WIDTH, MOBILE_HOLD_HEIGHT, "HOLD");
+
+    // Hold Touch Zone
+    const holdZone = scene.add.zone(holdX, holdY, MOBILE_HOLD_WIDTH, MOBILE_HOLD_HEIGHT).setOrigin(0);
+    holdZone.setInteractive();
+    holdZone.on('pointerdown', () => {
+        if (isInputBlocked()) return;
+        onHoldInput('hold', InputState.PRESS);
+        scene.time.delayedCall(100, () => onHoldInput('hold', InputState.RELEASE));
+    });
+
+    // Queue (above-right of play field, single next piece)
+    const queueX = fieldX + rawPlayFieldWidth - MOBILE_HOLD_WIDTH - BLOCK_SIZE;
+    const queueY = holdY - BLOCK_SIZE;
+    const tetrominoQueue = new TetrominoBoxQueue(scene, queueX, queueY, MOBILE_QUEUE_SIZE);
+
+    // Play Field
+    const playField = new PlayField(scene, fieldX, fieldY, rawPlayFieldWidth, rawPlayFieldHeight);
+
+    // Level Indicator (compact, below play field)
+    const infoX = fieldX;
+    const infoY = fieldY + rawPlayFieldHeight + GAP;
+    const levelIndicator = new LevelIndicator(scene, infoX, infoY, { compact: true });
 
     // Engine
     const engine = new Engine(playField, holdBox, tetrominoQueue, levelIndicator);

--- a/src/tetris/ui/leaderboardPanel.ts
+++ b/src/tetris/ui/leaderboardPanel.ts
@@ -9,11 +9,14 @@ export class LeaderboardPanel {
     private container: HTMLElement;
     private myPlayerId: string;
 
-    constructor(myPlayerId: string) {
+    constructor(myPlayerId: string, layoutMode?: string) {
         this.myPlayerId = myPlayerId;
 
         this.container = document.createElement('div');
         this.container.className = 'nmulti-leaderboard';
+        if (layoutMode === 'mobile-portrait') {
+            this.container.classList.add('nmulti-leaderboard--portrait');
+        }
         this.container.innerHTML = '<div class="lb-title">LEADERBOARD</div><div class="lb-list"></div>';
         document.body.appendChild(this.container);
     }

--- a/styles/css/modern-ui.css
+++ b/styles/css/modern-ui.css
@@ -356,3 +356,123 @@
     font-size: 12px;
     padding: 2px 0;
 }
+
+/* ─── Responsive: Tablet / Small Desktop ─────────────────────────── */
+@media (max-width: 768px) {
+    .menu-panel {
+        min-width: 320px;
+        padding: 40px 30px;
+        gap: 18px;
+    }
+
+    .menu-title {
+        font-size: 52px;
+        margin-bottom: 10px;
+    }
+
+    .menu-score {
+        font-size: 36px;
+        padding: 8px 20px;
+    }
+
+    .puyo-btn {
+        min-width: 240px;
+        font-size: 28px;
+        padding: 12px 35px;
+        margin: 10px;
+    }
+
+    .game-title {
+        font-size: 80px;
+        margin-bottom: 30px;
+    }
+
+    .nmulti-leaderboard {
+        width: 200px;
+    }
+
+    .lobby-container {
+        padding: 20px;
+    }
+
+    .lobby-title {
+        font-size: 36px;
+    }
+}
+
+/* ─── Responsive: Phone ──────────────────────────────────────────── */
+@media (max-width: 480px) {
+    .menu-panel {
+        min-width: unset;
+        width: 90vw;
+        padding: 30px 20px;
+        gap: 14px;
+        border-radius: 24px;
+    }
+
+    .menu-title {
+        font-size: 40px;
+        -webkit-text-stroke: 3px var(--primary-color);
+    }
+
+    .menu-score {
+        font-size: 28px;
+        padding: 6px 16px;
+    }
+
+    .game-title {
+        font-size: 56px;
+        margin-bottom: 20px;
+    }
+
+    .puyo-btn {
+        min-width: 200px;
+        font-size: 22px;
+        padding: 10px 25px;
+        margin: 8px;
+        border-radius: 30px;
+    }
+
+    .lobby-container {
+        padding: 15px;
+        border-radius: 20px;
+    }
+
+    .lobby-title {
+        font-size: 28px;
+    }
+
+    .room-name {
+        font-size: 18px;
+    }
+
+    .room-players {
+        font-size: 14px;
+        margin-right: 10px;
+    }
+
+    .room-item {
+        padding: 10px 15px;
+    }
+}
+
+/* ─── Responsive: Phone Portrait ─────────────────────────────────── */
+@media (max-width: 480px) and (orientation: portrait) {
+    .nmulti-leaderboard {
+        top: auto;
+        bottom: 5px;
+        left: 5px;
+        right: 5px;
+        width: auto;
+        max-height: 150px;
+        border-radius: 10px;
+    }
+
+    .nmulti-leaderboard.nmulti-leaderboard--portrait {
+        top: auto;
+        bottom: 5px;
+        left: 5px;
+        right: 5px;
+        width: auto;
+    }
+}


### PR DESCRIPTION
## Summary

- **Mobile portrait layout**: Detects mobile devices (`min(w,h) < 768`) and rearranges game elements vertically — hold+next above playfield, compact stats below — maximizing playfield zoom (~0.97 vs 0.53 on iPhone SE)
- **MiniPlayField fixes**: Cap name font size and crop to field width, fix grid row overlap by using proper height factor (24 cell-size units), replace DOM leaderboard with inline `#rank` + score display per mini-field
- **Touch fix**: Use world-space center for rotation tap detection instead of screen pixels
- **Action text fix**: Always call `setAction` on piece lock so text clears immediately on non-clearing locks

## Test plan

- [ ] Desktop (1920x1080): verify single/multi/n-multi layout is identical to before
- [ ] Mobile portrait (DevTools iPhone 14 Pro, 393x852): hold+next above field, compact stats below, menu buttons fit
- [ ] Mobile landscape: behaves like desktop
- [ ] N-multi with many players: mini-fields don't overlap, name text stays within bounds, rank shows correctly
- [ ] Touch rotation: tap left/right of center triggers CCW/CW correctly
- [ ] Action text ("Single", "Double") disappears promptly after next piece locks
- [ ] `npm test` — all 220 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)