### PR TITLE
feat(multiplayer): improve 1v1 disconnect handling with in-game notice

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -135,28 +135,35 @@ io.on('connection', (socket) => {
     socket.on('join_or_create', (data) => {
         const roomName = (data && data.roomName) || 'Room';
 
-        // Find existing waiting room by name
-        let existingRoomId = null;
+        // Find existing room by name (check both waiting and playing)
+        let existingWaitingRoomId = null;
+        let existingPlayingRoomId = null;
         for (const roomId in rooms) {
-            if (rooms[roomId].name === roomName && rooms[roomId].status === 'waiting') {
-                existingRoomId = roomId;
-                break;
+            if (rooms[roomId].name === roomName) {
+                if (rooms[roomId].status === 'waiting') {
+                    existingWaitingRoomId = roomId;
+                    break;
+                } else if (rooms[roomId].status === 'playing') {
+                    existingPlayingRoomId = roomId;
+                }
             }
         }
 
-        if (existingRoomId) {
+        if (existingWaitingRoomId) {
             // Join existing room as p2
-            const room = rooms[existingRoomId];
+            const room = rooms[existingWaitingRoomId];
             room.p2 = socket.id;
             room.status = 'playing';
 
-            socket.join(existingRoomId);
-            socket.emit('room_joined', { roomId: existingRoomId, isHost: false, roomName: room.name });
+            socket.join(existingWaitingRoomId);
+            socket.emit('room_joined', { roomId: existingWaitingRoomId, isHost: false, roomName: room.name });
 
             io.to(room.p1).emit('opponent_joined', { opponentId: socket.id });
             socket.emit('opponent_joined', { opponentId: room.p1 });
 
             io.emit('room_list', getRoomList());
+        } else if (existingPlayingRoomId) {
+            socket.emit('room_error', 'Game is already in progress in this room.');
         } else {
             // Create new room
             const roomId = crypto.randomUUID();

--- a/server/index.js
+++ b/server/index.js
@@ -442,10 +442,41 @@ io.on('connection', (socket) => {
         let roomChanged = false;
         for (const roomId in rooms) {
             const room = rooms[roomId];
-            if (room.p1 === socket.id || room.p2 === socket.id) {
-                io.to(roomId).emit('opponent_disconnected');
+            if (room.p1 !== socket.id && room.p2 !== socket.id) {
+                continue;
+            }
+
+            roomChanged = true;
+
+            // Host left: promote guest to host and keep room waiting.
+            if (room.p1 === socket.id && room.p2) {
+                const remainingPlayer = room.p2;
+                room.p1 = remainingPlayer;
+                room.p2 = null;
+                room.status = 'waiting';
+                room.p1Ready = true;
+                room.p2Ready = false;
+                io.to(remainingPlayer).emit('opponent_disconnected', {
+                    message: 'Opponent left. Waiting for a new player...'
+                });
+                continue;
+            }
+
+            // Guest left: keep host in the room and return to waiting state.
+            if (room.p2 === socket.id) {
+                room.p2 = null;
+                room.status = 'waiting';
+                room.p1Ready = true;
+                room.p2Ready = false;
+                io.to(room.p1).emit('opponent_disconnected', {
+                    message: 'Opponent left. Waiting for a new player...'
+                });
+                continue;
+            }
+
+            // Host left while waiting: remove empty room.
+            if (room.p1 === socket.id) {
                 delete rooms[roomId];
-                roomChanged = true;
             }
         }
         if (roomChanged) {

--- a/src/tetris/scenes/playScene.ts
+++ b/src/tetris/scenes/playScene.ts
@@ -44,6 +44,7 @@ export class PlayScene extends BaseScene {
     private isGameEnded: boolean = false;
     private botLevel: number = 0;
     private botManager: BotManager;
+    private disconnectNoticeDOM: Phaser.GameObjects.DOMElement | null = null;
 
     // Configurable Scales
     private readonly MAIN_SCALE = 1;
@@ -120,6 +121,10 @@ export class PlayScene extends BaseScene {
 
         if (this.socket) {
             this.socket.on('game_start', () => {
+                if (this.disconnectNoticeDOM) {
+                    this.disconnectNoticeDOM.destroy();
+                    this.disconnectNoticeDOM = null;
+                }
                 this.statusText.setVisible(false);
                 this.startGame();
             });
@@ -146,14 +151,66 @@ export class PlayScene extends BaseScene {
                 this.scene.restart({ mode: 'multi', socket: this.socket, roomId: this.roomId, roomName: this.roomName, botLevel: this.botLevel });
             });
 
-            this.socket.on('opponent_disconnected', () => {
-                history.replaceState(null, '', '/');
-                alert('Opponent disconnected!');
-                this.scene.start('LobbyScene');
+            this.socket.on('opponent_disconnected', (data?: { message?: string }) => {
+                this.handleOpponentDisconnected(data?.message);
             });
 
             this.socket.emit('player_ready', { roomId: this.roomId });
         }
+    }
+
+    private handleOpponentDisconnected(message?: string) {
+        if (this.mode !== 'multi' || !this.socket) {
+            return;
+        }
+
+        this.isGameRunning = false;
+        this.isGameEnded = false;
+        this.inputManager.isEnabled = false;
+
+        if (this.botManager) {
+            this.botManager.stop();
+        }
+        if (this.playField) {
+            this.playField.stop();
+        }
+
+        this.showDisconnectNotice(message || 'Opponent left. Waiting for a new player...');
+
+        this.socket.emit('player_ready', { roomId: this.roomId });
+    }
+
+    private showDisconnectNotice(message: string) {
+        if (this.disconnectNoticeDOM) {
+            this.disconnectNoticeDOM.destroy();
+            this.disconnectNoticeDOM = null;
+        }
+
+        this.statusText
+            .setText('Waiting for opponent...')
+            .setVisible(true)
+            .setDepth(1000);
+
+        const html = `
+        <div class="disconnect-notice-overlay" style="width: ${this.GAME_WIDTH}px; height: ${this.GAME_HEIGHT}px;">
+            <div class="menu-panel disconnect-notice-panel">
+                <div class="menu-title disconnect-notice-title">NOTICE</div>
+                <div class="disconnect-notice-message">${message}</div>
+            </div>
+        </div>
+        `;
+
+        this.disconnectNoticeDOM = this.add.dom(this.GAME_WIDTH / 2, this.GAME_HEIGHT / 2).createFromHTML(html);
+        this.disconnectNoticeDOM.setDepth(1001);
+        this.disconnectNoticeDOM.setScale(this.cameras.main.zoom);
+
+        this.time.delayedCall(2500, () => {
+            if (!this.disconnectNoticeDOM) {
+                return;
+            }
+            this.disconnectNoticeDOM.destroy();
+            this.disconnectNoticeDOM = null;
+        });
     }
 
     private shutdown() {
@@ -168,6 +225,10 @@ export class PlayScene extends BaseScene {
             this.socket.off('opponent_game_over');
             this.socket.off('restart_signal');
             this.socket.off('opponent_disconnected');
+        }
+        if (this.disconnectNoticeDOM) {
+            this.disconnectNoticeDOM.destroy();
+            this.disconnectNoticeDOM = null;
         }
         if (this.inGameMenu) {
             this.inGameMenu.destroy();
@@ -308,6 +369,14 @@ export class PlayScene extends BaseScene {
                 fontSize: isPortrait ? '16px' : '20px',
                 color: '#ffffff',
             });
+        }
+    }
+
+
+    resize(gameSize, baseSize?, displaySize?, resolution?) {
+        super.resize(gameSize, baseSize, displaySize, resolution);
+        if (this.disconnectNoticeDOM && this.cameras && this.cameras.main) {
+            this.disconnectNoticeDOM.setScale(this.cameras.main.zoom);
         }
     }
 

--- a/src/tetris/scenes/playScene.ts
+++ b/src/tetris/scenes/playScene.ts
@@ -45,6 +45,7 @@ export class PlayScene extends BaseScene {
     private botLevel: number = 0;
     private botManager: BotManager;
     private disconnectNoticeDOM: Phaser.GameObjects.DOMElement | null = null;
+    private startImmediately: boolean = false;
 
     // Configurable Scales
     private readonly MAIN_SCALE = 1;
@@ -73,6 +74,7 @@ export class PlayScene extends BaseScene {
         this.isGameRunning = false;
         this.isGameEnded = false;
         this.lastUpdateSend = 0;
+        this.startImmediately = data.startImmediately || false;
     }
 
     preload(): void { }
@@ -111,6 +113,10 @@ export class PlayScene extends BaseScene {
             this.startGame();
         } else {
             this.setupMultiplayer();
+            if (this.startImmediately) {
+                this.statusText.setVisible(false);
+                this.startGame();
+            }
         }
 
         this.events.on('shutdown', this.shutdown, this);
@@ -121,6 +127,21 @@ export class PlayScene extends BaseScene {
 
         if (this.socket) {
             this.socket.on('game_start', () => {
+                if (this.isGameRunning) return;
+
+                if (this.playField) {
+                    // Previous game objects exist — restart scene cleanly
+                    this.scene.restart({
+                        mode: 'multi',
+                        socket: this.socket,
+                        roomId: this.roomId,
+                        roomName: this.roomName,
+                        botLevel: this.botLevel,
+                        startImmediately: true
+                    });
+                    return;
+                }
+
                 if (this.disconnectNoticeDOM) {
                     this.disconnectNoticeDOM.destroy();
                     this.disconnectNoticeDOM = null;

--- a/styles/css/modern-ui.css
+++ b/styles/css/modern-ui.css
@@ -493,3 +493,37 @@
         width: auto;
     }
 }
+
+
+.disconnect-notice-panel {
+    min-width: 520px;
+    border-color: var(--secondary-color);
+}
+
+.disconnect-notice-title {
+    font-size: 64px;
+    -webkit-text-stroke: 3px var(--secondary-color);
+    margin-bottom: 8px;
+}
+
+.disconnect-notice-message {
+    font-family: var(--font-game);
+    font-size: 30px;
+    color: #ffffff;
+    text-align: center;
+    line-height: 1.35;
+    max-width: 520px;
+}
+
+
+.disconnect-notice-overlay {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    pointer-events: auto;
+}


### PR DESCRIPTION
## Summary
- Improve 1v1 multiplayer disconnect handling so the remaining player stays in the room instead of being kicked to the lobby
- Server promotes guest to host when the host leaves, keeping the room in `waiting` state for a new opponent
- Replace `alert()` + forced lobby redirect with an in-game overlay notice ("Opponent left. Waiting for a new player...")
- Automatically re-emit `player_ready` so the remaining player seamlessly waits for a new match

## Changes

### Server (`server/index.js`)
- Split disconnect logic into 3 cases: host leaves (promote guest), guest leaves (keep host), host leaves alone (delete room)
- Add `message` field to `opponent_disconnected` event

### Client (`src/tetris/scenes/playScene.ts`)
- Add `handleOpponentDisconnected()`: stops game, re-emits `player_ready` to wait for next opponent
- Add `showDisconnectNotice()`: DOM overlay with blur background, auto-dismissed after 2.5s
- Add `resize()` override to keep overlay scale in sync with camera zoom
- Clean up overlay on `game_start`, `shutdown`

### Styles (`styles/css/modern-ui.css`)
- Add `.disconnect-notice-overlay`, `.disconnect-notice-panel`, `.disconnect-notice-title`, `.disconnect-notice-message` styles

## Test plan
- [ ] Start 1v1 game with two players, disconnect one — verify remaining player sees overlay notice and stays in room
- [ ] Verify a new player can join the same room and game starts automatically
- [ ] Test host disconnect (p1) — verify guest is promoted to host
- [ ] Test guest disconnect (p2) — verify host stays and waits
- [ ] Test disconnect while waiting (no opponent) — verify room is deleted
- [ ] Verify overlay scales correctly on window resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)