### PR TITLE
Improve multiplayer performance: pooling, encoded-board, server dirty broadcasts

### DIFF
--- a/docs/performance-analysis.md
+++ b/docs/performance-analysis.md
@@ -1,0 +1,110 @@
+# 성능 최적화 분석 (qufox-tetris)
+
+## 분석 범위
+- 클라이언트 렌더링 경로 (Phaser Scene/오브젝트)
+- 멀티플레이 네트워크 직렬화/역직렬화 경로
+- 서버 N-Multi 스냅샷 브로드캐스트 경로
+
+## 우선순위 높은 최적화 후보
+
+### 1) N-Multi 미니 보드 렌더링의 과도한 재생성
+**현상**
+- `MiniPlayField.updateState()`가 호출될 때마다 `redraw()`를 실행합니다.
+- `redraw()` 내부에서 매번 `BoardCodec.decode()`를 호출하고, 기존 블록 이미지를 `removeAll(true)`로 전부 파괴한 뒤 새 이미지들을 다시 생성합니다.
+
+**근거 코드**
+- `updateState()` → `redraw()` 호출: `src/tetris/objects/miniPlayField.ts`
+- `redraw()`에서 `removeAll(true)` + `BoardCodec.decode()` + 이미지 재생성: `src/tetris/objects/miniPlayField.ts`
+
+**영향**
+- 상대 수가 늘수록(최대 100명) GC/드로우콜/오브젝트 생성 비용이 급증할 수 있습니다.
+- 500ms 스냅샷 주기와 결합되면 프레임 드랍의 주요 원인이 됩니다.
+
+**개선 제안**
+- 오브젝트 풀링: 미니 필드당 최대 200칸 스프라이트를 재사용(visible/frame/x/y만 갱신).
+- 변경분 렌더링(diff): 이전 보드 문자열과 비교해 바뀐 셀만 갱신.
+- `updateState`에서 점수/생존 상태만 변하고 보드 문자열이 동일한 경우 `redraw()` 스킵.
+
+---
+
+### 2) 1v1/N-Multi 상태 직렬화 시 객체 할당 과다
+**현상**
+- `PlayField.serialize()`가 호출될 때마다 `{ col, row, type }` 객체 배열을 새로 생성합니다.
+- 1v1은 약 10Hz, N-Multi는 5Hz로 주기적으로 직렬화가 발생합니다.
+
+**근거 코드**
+- 직렬화 구현: `src/tetris/objects/playField.ts`
+- 1v1 전송 루프(100ms): `src/tetris/scenes/playScene.ts`
+- N-Multi 전송 루프(200ms): `src/tetris/scenes/nMultiPlayScene.ts`
+
+**영향**
+- 고빈도 직렬화에서 단기 객체가 대량 생성되어 GC pressure가 커집니다.
+
+**개선 제안**
+- 내부 보드를 200칸 고정 배열/TypedArray로 유지하고, 네트워크 전송용 문자열을 증분 갱신.
+- `serialize()` 결과 캐싱: 보드 변경 시에만 invalidate.
+- N-Multi는 이미 `BoardCodec.encode()`를 쓰므로, `PlayField` 단계에서 바로 인코딩 문자열을 제공하는 API 추가 검토.
+
+---
+
+### 3) `getInactiveBlocks()`/라인 클리어 계산의 반복 순회
+**현상**
+- `getInactiveBlocks()`가 `map + reduce + concat`으로 매번 새 배열을 만듭니다.
+- `getClearedRows()`는 후보 행마다 `filter`로 전체 블록을 재탐색합니다.
+
+**근거 코드**
+- `getInactiveBlocks()`: `src/tetris/objects/playField.ts`
+- `getClearedRows()`: `src/tetris/objects/playField.ts`
+
+**영향**
+- 블록 수가 많은 구간에서 연산량(O(n*r))과 메모리 할당량이 증가합니다.
+
+**개선 제안**
+- 필드 occupancy(예: `rowCounts[20]`, `grid[20][10]`)를 상시 유지해 즉시 조회.
+- `getInactiveBlocks()` 결과 재사용 또는 iterator 기반 순회로 중간 배열 제거.
+- 클리어 판정은 잠긴 테트로미노가 닿은 행에 대해 `rowCounts[row] === 10`으로 O(k) 처리.
+
+---
+
+### 4) 서버 N-Multi 스냅샷 브로드캐스트의 전체 스캔 구조
+**현상**
+- 방마다 `setInterval(500ms)`를 두고 모든 플레이어를 순회해 버전(`v`) 비교 후 델타를 구성합니다.
+- 방 생성 경로가 두 곳이며 각각 interval 생성 로직이 중복됩니다.
+
+**근거 코드**
+- interval 생성: `server/index.js`
+- 델타 브로드캐스트 루프: `server/index.js`의 `broadcastNMultiSnapshot`
+
+**영향**
+- 방/플레이어 수가 커질수록 이벤트 루프 부담과 직렬화 비용이 선형 증가.
+
+**개선 제안**
+- 이벤트 기반 dirty-set: `nmulti_update_state`에서 변경된 socket id를 room dirty set에 기록 후, tick에서는 dirty만 직렬화.
+- interval 생성 코드 공통화로 유지보수 비용/실수 가능성 감소.
+- 대규모 방에서는 고정 주기 + 최대 패킷 크기 제한(백프레셔) 전략 도입.
+
+---
+
+### 5) 런타임 로그 과다 가능성
+**현상**
+- 락/콤보 이벤트마다 `console.log`가 발생합니다.
+
+**근거 코드**
+- `Engine.onLock()`: `src/tetris/engine.ts`
+
+**영향**
+- 브라우저 콘솔 I/O가 많은 환경에서 메인스레드 지연 유발 가능.
+
+**개선 제안**
+- `NODE_ENV !== 'production'` 또는 디버그 플래그 기반 로깅 가드.
+
+## 실행 순서 제안 (ROI 기준)
+1. `MiniPlayField` diff 렌더링 + 오브젝트 풀링
+2. `PlayField` 직렬화 캐싱/증분화
+3. `PlayField` 내부 occupancy 캐시 도입
+4. 서버 dirty-set 브로드캐스트
+5. 디버그 로깅 가드
+
+## 간단 측정 지표 (적용 전/후 비교)
+- 클라이언트: FPS, frame time p95, GC pause, JS heap size, 네트워크 송수신 바이트/초
+- 서버: room당 tick 처리시간 p95, emit payload 크기, 이벤트 루프 지연

--- a/server/index.js
+++ b/server/index.js
@@ -48,8 +48,43 @@ let nMultiRooms = {};
 //   playerCounter: number,
 //   players: { [socketId]: { name, score, level, lines, board, isAlive, v } },
 //   lastBroadcasted: { [socketId]: string },
+//   dirtyPlayers: Set<string>,
 //   _broadcastInterval: NodeJS.Timer
 // }
+
+function createNMultiRoom(roomId, roomName, hostSocketId, hostName) {
+    nMultiRooms[roomId] = {
+        id: roomId,
+        name: roomName,
+        playerCounter: 1,
+        players: {
+            [hostSocketId]: {
+                name: hostName,
+                score: 0,
+                level: 1,
+                lines: 0,
+                board: null,
+                isAlive: true,
+                v: 0
+            }
+        },
+        lastBroadcasted: {},
+        dirtyPlayers: new Set([hostSocketId]),
+        _broadcastInterval: setInterval(() => {
+            broadcastNMultiSnapshot(roomId);
+        }, 500)
+    };
+
+    return nMultiRooms[roomId];
+}
+
+function markNMultiPlayerDirty(room, playerId) {
+    if (!room || !playerId) return;
+    if (!room.dirtyPlayers) {
+        room.dirtyPlayers = new Set();
+    }
+    room.dirtyPlayers.add(playerId);
+}
 
 io.on('connection', (socket) => {
     console.log('A user connected:', socket.id);
@@ -193,33 +228,10 @@ io.on('connection', (socket) => {
         const roomId = crypto.randomUUID();
         const playerName = RANDOM_NAMES[Math.floor(Math.random() * RANDOM_NAMES.length)];
 
-        nMultiRooms[roomId] = {
-            id: roomId,
-            name: roomName,
-            playerCounter: 1,
-            players: {
-                [socket.id]: {
-                    name: playerName,
-                    score: 0,
-                    level: 1,
-                    lines: 0,
-                    board: null,
-                    isAlive: true,
-                    v: 0
-                }
-            },
-            lastBroadcasted: {},
-            _broadcastInterval: null
-        };
+        const room = createNMultiRoom(roomId, roomName, socket.id, playerName);
 
         socket.join(roomId);
 
-        // Start broadcast interval
-        nMultiRooms[roomId]._broadcastInterval = setInterval(() => {
-            broadcastNMultiSnapshot(roomId);
-        }, 500);
-
-        const room = nMultiRooms[roomId];
         socket.emit('nmulti_room_joined', {
             roomId,
             playerId: socket.id,
@@ -258,8 +270,10 @@ io.on('connection', (socket) => {
             level: 1,
             lines: 0,
             board: null,
-            isAlive: true
+            isAlive: true,
+            v: 0
         };
+        markNMultiPlayerDirty(room, socket.id);
 
         socket.join(roomId);
 
@@ -299,6 +313,7 @@ io.on('connection', (socket) => {
         
         if (changed) {
             player.v++;
+            markNMultiPlayerDirty(room, socket.id);
         }
     });
 
@@ -318,6 +333,8 @@ io.on('connection', (socket) => {
         const room = nMultiRooms[data.roomId];
         if (!room || !room.players[socket.id]) return;
         room.players[socket.id].isAlive = false;
+        room.players[socket.id].v++;
+        markNMultiPlayerDirty(room, socket.id);
     });
 
     socket.on('nmulti_join_or_create', (data) => {
@@ -357,6 +374,7 @@ io.on('connection', (socket) => {
                 isAlive: true,
                 v: 0
             };
+            markNMultiPlayerDirty(room, socket.id);
 
             socket.join(existingRoomId);
 
@@ -379,37 +397,16 @@ io.on('connection', (socket) => {
             const roomId = crypto.randomUUID();
             const playerName = RANDOM_NAMES[Math.floor(Math.random() * RANDOM_NAMES.length)];
 
-            nMultiRooms[roomId] = {
-                id: roomId,
-                name: roomName,
-                playerCounter: 1,
-                players: {
-                    [socket.id]: {
-                        name: playerName,
-                        score: 0,
-                        level: 1,
-                        lines: 0,
-                        board: null,
-                        isAlive: true,
-                        v: 0
-                    }
-                },
-                lastBroadcasted: {},
-                _broadcastInterval: null
-            };
+            const room = createNMultiRoom(roomId, roomName, socket.id, playerName);
 
             socket.join(roomId);
-
-            nMultiRooms[roomId]._broadcastInterval = setInterval(() => {
-                broadcastNMultiSnapshot(roomId);
-            }, 500);
 
             socket.emit('nmulti_room_joined', {
                 roomId,
                 playerId: socket.id,
                 playerName,
                 roomName,
-                players: getPlayersMap(nMultiRooms[roomId])
+                players: getPlayersMap(room)
             });
 
             io.emit('nmulti_room_list', getNMultiRoomList());
@@ -439,6 +436,7 @@ io.on('connection', (socket) => {
         player.board = null;
         player.isAlive = true;
         player.v++;
+        markNMultiPlayerDirty(room, socket.id);
     });
 
     // ===== Disconnect =====
@@ -532,14 +530,14 @@ function broadcastNMultiSnapshot(roomId) {
     const room = nMultiRooms[roomId];
     if (!room) return;
 
-    const playerIds = Object.keys(room.players);
-    if (playerIds.length === 0) return;
+    const dirtyPlayers = room.dirtyPlayers ? Array.from(room.dirtyPlayers) : [];
+    if (dirtyPlayers.length === 0) return;
 
     const deltaSnapshot = {};
-    let hasChanges = false;
 
-    for (const sid of playerIds) {
+    for (const sid of dirtyPlayers) {
         const p = room.players[sid];
+        if (!p) continue;
         
         if (room.lastBroadcasted[sid] !== p.v) {
             deltaSnapshot[sid] = {
@@ -552,11 +550,12 @@ function broadcastNMultiSnapshot(roomId) {
                 v: p.v
             };
             room.lastBroadcasted[sid] = p.v;
-            hasChanges = true;
         }
     }
 
-    if (hasChanges) {
+    room.dirtyPlayers.clear();
+
+    if (Object.keys(deltaSnapshot).length > 0) {
         // Broadcast single packet to all
         io.to(roomId).emit('nmulti_snapshot', { 
             players: deltaSnapshot,
@@ -571,6 +570,7 @@ function removeFromNMultiRoom(socket, roomId) {
 
     delete room.players[socket.id];
     if (room.lastBroadcasted) delete room.lastBroadcasted[socket.id];
+    if (room.dirtyPlayers) room.dirtyPlayers.delete(socket.id);
     socket.leave(roomId);
 
     const remaining = Object.keys(room.players).length;

--- a/src/tetris/engine.ts
+++ b/src/tetris/engine.ts
@@ -15,6 +15,7 @@ export class Engine {
     private levelIndicator: LevelIndicator;
     private scoreSystem: ScoreSystem;
     private gameTime: number = 0;
+    private readonly isDebugLogging: boolean = typeof process !== 'undefined' ? process.env.NODE_ENV !== 'production' : true;
 
     private onAttack: (count: number) => void;
 
@@ -136,13 +137,10 @@ export class Engine {
             tSpinCornerOccupiedCount
         );
 
-        if (result.scoreAdded > 0 && result.actionName) {
+        if (this.isDebugLogging && result.scoreAdded > 0 && result.actionName) {
             console.log(`${result.actionName} - ${result.scoreAdded}`);
         }
-        if (result.combo > 0) {
-            const comboScore = 50 * result.combo * result.level; // Logic duplication for logging?
-            // Better rely on ScoreSystem to return combo score details if we want detailed logs,
-            // but for now simple log is fine.
+        if (this.isDebugLogging && result.combo > 0) {
              console.log(`Combo ${result.combo}`);
         }
 
@@ -192,7 +190,9 @@ export class Engine {
      * Game over. emit from play field, when can not create tetromino anymore.
      */
     gameOver(gameOverType) {
-        console.log(`Game Over - ${gameOverType}`);
+        if (this.isDebugLogging) {
+            console.log(`Game Over - ${gameOverType}`);
+        }
     }
 
     /**

--- a/src/tetris/objects/miniPlayField.ts
+++ b/src/tetris/objects/miniPlayField.ts
@@ -33,6 +33,8 @@ export class MiniPlayField {
     private _isAlive: boolean = true;
     private _board: string | null = null;
     private _score: number = 0;
+    private _lastRenderedBoard: string | null = null;
+    private blockPool: Phaser.GameObjects.Image[] = [];
 
     public playerId: string;
     public playerName: string;
@@ -92,12 +94,21 @@ export class MiniPlayField {
     }
 
     updateState(board: string | null, score: number, isAlive: boolean) {
+        const boardChanged = this._board !== board;
+        const aliveChanged = this._isAlive !== isAlive;
+
         this._board = board;
         this._isAlive = isAlive;
         this._score = score;
         this.scoreText.setText(score.toString());
-        this.redraw();
-        this.updateGameOverOverlay();
+
+        if (boardChanged) {
+            this.redrawBoard();
+        }
+
+        if (aliveChanged || boardChanged) {
+            this.updateGameOverOverlay();
+        }
     }
 
     updateRank(rank: number) {
@@ -136,7 +147,8 @@ export class MiniPlayField {
         this.gameOverScoreText.setFontSize(goScoreFontSize);
         this.gameOverScoreText.setPosition(fieldWidth / 2, fieldHeight / 2 + goFontSize * 0.6);
 
-        this.redraw();
+        this.redrawBackground();
+        this.redrawBoard(true);
     }
 
     private updateGameOverOverlay() {
@@ -158,11 +170,10 @@ export class MiniPlayField {
         }
     }
 
-    private redraw() {
+    private redrawBackground() {
         const cellSize = this._cellSize;
         const fieldWidth = cellSize * COLS;
         const fieldHeight = cellSize * ROWS;
-        const blockScale = cellSize / BLOCK_IMAGE_SIZE;
 
         // Background
         this.bgGraphics.clear();
@@ -170,26 +181,46 @@ export class MiniPlayField {
         this.bgGraphics.fillRect(0, 0, fieldWidth, fieldHeight);
         this.bgGraphics.lineStyle(1, 0xaaaaaa, 0.5);
         this.bgGraphics.strokeRect(0, 0, fieldWidth, fieldHeight);
+    }
 
-        // Clear old block images
-        this.blockContainer.removeAll(true);
+    private redrawBoard(force = false) {
+        const cellSize = this._cellSize;
+        const blockScale = cellSize / BLOCK_IMAGE_SIZE;
 
-        // Draw blocks
+        if (!force && this._board === this._lastRenderedBoard) {
+            return;
+        }
+
+        let used = 0;
+
         if (this._board) {
             const blocks = BoardCodec.decode(this._board);
             for (const b of blocks) {
                 const frame = SPRITE_FRAMES[b.type] ?? 7;
-                const img = this.scene.add.image(
-                    b.col * cellSize,
-                    b.row * cellSize,
-                    'blockSheet',
-                    frame
-                );
-                img.setOrigin(0);
+                const img = this.ensurePooledImage(used++);
+                img.setFrame(frame);
+                img.setPosition(b.col * cellSize, b.row * cellSize);
                 img.setScale(blockScale);
-                this.blockContainer.add(img);
+                img.setVisible(true);
             }
         }
+
+        for (let i = used; i < this.blockPool.length; i++) {
+            this.blockPool[i].setVisible(false);
+        }
+
+        this._lastRenderedBoard = this._board;
+    }
+
+    private ensurePooledImage(index: number): Phaser.GameObjects.Image {
+        if (!this.blockPool[index]) {
+            const img = this.scene.add.image(0, 0, 'blockSheet', 0);
+            img.setOrigin(0);
+            this.blockContainer.add(img);
+            this.blockPool[index] = img;
+        }
+
+        return this.blockPool[index];
     }
 
     destroy() {

--- a/src/tetris/objects/playField.ts
+++ b/src/tetris/objects/playField.ts
@@ -3,8 +3,21 @@ import {ObjectBase} from './objectBase';
 import {Tetromino} from "./tetromino";
 import {PlayFieldEffects} from "../view/playFieldEffects";
 import {GarbageGenerator} from "../logic/garbageGenerator";
+import { BoardCodec } from "../net/boardCodec";
+
 
 const BLOCK_SIZE = getBlockSize();
+const TYPE_TO_CHAR: Record<string, string> = {
+    [TetrominoType.I]: 'I',
+    [TetrominoType.J]: 'J',
+    [TetrominoType.L]: 'L',
+    [TetrominoType.O]: 'O',
+    [TetrominoType.S]: 'S',
+    [TetrominoType.T]: 'T',
+    [TetrominoType.Z]: 'Z',
+    [TetrominoType.GARBAGE]: 'G',
+};
+
 /**
  * Play field
  */
@@ -19,6 +32,7 @@ export class PlayField extends ObjectBase {
     public autoDropDelay: number = 1000;
     private effects: PlayFieldEffects;
     private pendingClearedRows: number[] | null = null;
+    private inactiveBlocksCache: ColRow[] | null = null;
 
     public get activeTetrominoInstance(): Tetromino {
         return this.activeTetromino;
@@ -98,6 +112,11 @@ export class PlayField extends ObjectBase {
         this.activeTetromino = null;
         // Clear inactive tetrominos.
         this.inactiveTetrominos = [];
+        this.inactiveBlocksCache = [];
+    }
+
+    private invalidateInactiveBlocksCache() {
+        this.inactiveBlocksCache = null;
     }
 
     /**
@@ -146,8 +165,20 @@ export class PlayField extends ObjectBase {
      * Get inactive block positions.
      */
     getInactiveBlocks(): ColRow[] {
-        // Get all inactive tetromino blocks and aggregate.
-        return this.inactiveTetrominos.map(tetromino => tetromino.getBlocks()).reduce((a, b) => a.concat(b), []);
+        if (this.inactiveBlocksCache) {
+            return this.inactiveBlocksCache;
+        }
+
+        const blocks: ColRow[] = [];
+        for (const tetromino of this.inactiveTetrominos) {
+            const tetrominoBlocks = tetromino.getBlocks();
+            for (const block of tetrominoBlocks) {
+                blocks.push(block);
+            }
+        }
+
+        this.inactiveBlocksCache = blocks;
+        return blocks;
     }
 
     /**
@@ -235,9 +266,14 @@ export class PlayField extends ObjectBase {
         const rowsToCheck = new Set(lockedTetromino.getBlocks().map(([, row]) => row));
         const needClearRows: number[] = [];
         const inactiveBlocks = this.getInactiveBlocks();
+        const rowCounts = new Map<number, number>();
+
+        for (const [, row] of inactiveBlocks) {
+            rowCounts.set(row, (rowCounts.get(row) || 0) + 1);
+        }
 
         for (const row of rowsToCheck) {
-            const numberOfRowBlocks = inactiveBlocks.filter(([, r]) => r === row).length;
+            const numberOfRowBlocks = rowCounts.get(row) || 0;
             if (numberOfRowBlocks >= CONST.PLAY_FIELD.COL_COUNT) needClearRows.push(row);
         }
         return needClearRows;
@@ -270,6 +306,7 @@ export class PlayField extends ObjectBase {
                 this.inactiveTetrominos.splice(this.inactiveTetrominos.indexOf(tetromino), 1);
             });
         });
+        this.invalidateInactiveBlocksCache();
     }
 
     /**
@@ -333,6 +370,7 @@ export class PlayField extends ObjectBase {
             this.inactiveTetrominos.push(garbageTetromino);
             this.container.add(garbageTetromino.container);
         });
+        this.invalidateInactiveBlocksCache();
 
         // Update active tetromino's blocked positions map and ghost block
         if (this.activeTetromino) {
@@ -375,6 +413,34 @@ export class PlayField extends ObjectBase {
         return result;
     }
 
+
+    /**
+     * Serialize field state to 200-char encoded board string.
+     */
+    serializeEncoded(): string {
+        const grid = new Array(200).fill('0');
+
+        const writeBlocks = (tetromino: Tetromino, type: TetrominoType) => {
+            const blocks = tetromino.getBlocks();
+            const encodedType = TYPE_TO_CHAR[type] || '0';
+            for (const [col, row] of blocks) {
+                if (row >= 0 && row < CONST.PLAY_FIELD.ROW_COUNT && col >= 0 && col < CONST.PLAY_FIELD.COL_COUNT) {
+                    grid[row * CONST.PLAY_FIELD.COL_COUNT + col] = encodedType;
+                }
+            }
+        };
+
+        for (const tetromino of this.inactiveTetrominos) {
+            writeBlocks(tetromino, tetromino.type);
+        }
+
+        if (this.activeTetromino) {
+            writeBlocks(this.activeTetromino, this.activeTetromino.type);
+        }
+
+        return grid.join('');
+    }
+
     /**
      * Deserialize field state (for opponent view).
      */
@@ -389,6 +455,14 @@ export class PlayField extends ObjectBase {
         dummy.setInactiveBlocks(blocks);
         this.inactiveTetrominos.push(dummy);
         this.container.add(dummy.container);
+        this.invalidateInactiveBlocksCache();
+    }
+
+    /**
+     * Deserialize encoded board state (for opponent view).
+     */
+    deserializeEncoded(encodedBoard: string | null) {
+        this.deserialize(BoardCodec.decode(encodedBoard || ''));
     }
 
     /**
@@ -410,6 +484,7 @@ export class PlayField extends ObjectBase {
         let lockedTetromino = this.activeTetromino;
         lockedTetromino.inactive();
         this.inactiveTetrominos.push(lockedTetromino);
+        this.invalidateInactiveBlocksCache();
         this.activeTetromino = null;
 
         // Check locked Tetromino is inside buffer zone entire.

--- a/src/tetris/scenes/nMultiPlayScene.ts
+++ b/src/tetris/scenes/nMultiPlayScene.ts
@@ -6,7 +6,6 @@ import { InputManager } from "../input/inputManager";
 import { InGameMenu } from "../ui/inGameMenu";
 import { BaseScene } from "./baseScene";
 import { MiniPlayField } from "../objects/miniPlayField";
-import { BoardCodec } from "../net/boardCodec";
 import { BotManager } from "../logic/botManager";
 import { GAME_FONT_FAMILY } from "../ui/uiStyles";
 import {
@@ -446,8 +445,7 @@ export class NMultiPlayScene extends BaseScene {
             this.lastUpdateSend = time;
             if (this.playField && this.socket) {
                 const stats = this.engine.getStats();
-                const boardBlocks = this.playField.serialize();
-                const board = BoardCodec.encode(boardBlocks);
+                const board = this.playField.serializeEncoded();
                 this.socket.emit('nmulti_update_state', {
                     roomId: this.roomId,
                     score: stats.score,

--- a/src/tetris/scenes/playScene.ts
+++ b/src/tetris/scenes/playScene.ts
@@ -152,7 +152,11 @@ export class PlayScene extends BaseScene {
 
             this.socket.on('opponent_state_update', (data) => {
                 if (this.opponentPlayField) {
-                    this.opponentPlayField.deserialize(data.board);
+                    if (typeof data.board === 'string') {
+                        this.opponentPlayField.deserializeEncoded(data.board);
+                    } else {
+                        this.opponentPlayField.deserialize(data.board);
+                    }
                 }
             });
 
@@ -425,7 +429,7 @@ export class PlayScene extends BaseScene {
             if (this.playField && this.socket) {
                 this.socket.emit('update_state', {
                     roomId: this.roomId,
-                    board: this.playField.serialize()
+                    board: this.playField.serializeEncoded()
                 });
             }
         }


### PR DESCRIPTION
### Motivation
- Reduce CPU/GC pressure and network payload work in multiplayer paths by avoiding full redraws and excessive object allocations. 
- Emit smaller, targeted N-Multi snapshots instead of scanning all players every tick to lower server tick cost. 
- Provide a compact board representation for frequent client→server updates to reduce serialization overhead. 

### Description
- Replace full teardown redraw in `MiniPlayField` with separated background/board rendering, a `_lastRenderedBoard` check, and a `blockPool` image pool to reuse sprites and only update changed boards via `redrawBoard` and `redrawBackground`. 
- Add `inactiveBlocksCache` and an O(n) row counting approach in `PlayField` to avoid repeated `map/reduce/filter` allocations in `getInactiveBlocks` and `getClearedRows`, and invalidate the cache at state changes. 
- Add compact board serialization API `PlayField.serializeEncoded()` and `deserializeEncoded()` (200-char fixed grid string) and a `TYPE_TO_CHAR` table so scenes use encoded payloads; updated `playScene.ts` and `nMultiPlayScene.ts` to emit/handle the encoded board. 
- Server-side refactor: introduce `createNMultiRoom` helper, maintain a `dirtyPlayers` `Set` per room, mark players dirty on state changes, and change `broadcastNMultiSnapshot` to process only `dirtyPlayers` and clear the set after broadcasting to reduce per-tick scanning. 
- Guard noisy runtime logs behind a non-production debug flag (`isDebugLogging`) in `Engine` to reduce console spam in production. 

### Testing
- Ran targeted Jest suites and full test run: `npm test -- --runInBand --watch=false --testPathPattern="playScene|nMultiServer|boardCodec|guideline"` and `npm test -- --runInBand` and all reported tests passed. 
- Built the client bundle with `npm run build` and the production webpack build completed successfully. 
- Verified server script syntax with `node -c server/index.js` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b091d7cc832095a66d13f53d033c)