### PR TITLE
Refine overlay: remove mouse gamepad and add HOLD/NEXT‑styled MENU button

### DIFF
--- a/src/tetris/scenes/nMultiPlayScene.ts
+++ b/src/tetris/scenes/nMultiPlayScene.ts
@@ -8,6 +8,7 @@ import { BaseScene } from "./baseScene";
 import { MiniPlayField } from "../objects/miniPlayField";
 import { BotManager } from "../logic/botManager";
 import { GAME_FONT_FAMILY } from "../ui/uiStyles";
+import { GameOverlayControls } from "../ui/gameOverlayControls";
 import {
     createGameLayout,
     calcNMultiPlayerPosition,
@@ -34,6 +35,7 @@ export class NMultiPlayScene extends BaseScene {
     private isGameEnded: boolean = false;
     private botLevel: number = 0;
     private botManager: BotManager;
+    private overlayControls: GameOverlayControls;
 
     // Opponents
     private miniFields: Map<string, MiniPlayField> = new Map();
@@ -105,6 +107,11 @@ export class NMultiPlayScene extends BaseScene {
             onExit: () => this.exitGame(),
             onRestart: () => this.restartGame(),
             onToggleBackground: (btn) => this.toggleBackground(btn)
+        });
+
+        this.overlayControls = new GameOverlayControls({
+            scene: this,
+            onMenuClick: () => this.toggleMenu(),
         });
 
         this.opponentContainer = this.add.container(0, 0);
@@ -302,6 +309,9 @@ export class NMultiPlayScene extends BaseScene {
         if (this.inGameMenu) {
             this.inGameMenu.destroy();
         }
+        if (this.overlayControls) {
+            this.overlayControls.destroy();
+        }
         for (const [, mini] of this.miniFields) {
             mini.destroy();
         }
@@ -420,6 +430,13 @@ export class NMultiPlayScene extends BaseScene {
         }
 
         this.relayoutOpponents();
+    }
+
+    resize(gameSize, baseSize?, displaySize?, resolution?) {
+        super.resize(gameSize, baseSize, displaySize, resolution);
+        if (this.overlayControls) {
+            this.overlayControls.layout();
+        }
     }
 
     update(time: number, delta: number): void {

--- a/src/tetris/scenes/playScene.ts
+++ b/src/tetris/scenes/playScene.ts
@@ -13,6 +13,7 @@ import { InGameMenu } from "../ui/inGameMenu";
 import { BaseScene } from "./baseScene";
 import { BotManager } from "../logic/botManager";
 import { GAME_FONT_FAMILY } from "../ui/uiStyles";
+import { GameOverlayControls } from "../ui/gameOverlayControls";
 import {
     createGameLayout,
     calcSinglePlayerPosition,
@@ -46,6 +47,7 @@ export class PlayScene extends BaseScene {
     private botManager: BotManager;
     private disconnectNoticeDOM: Phaser.GameObjects.DOMElement | null = null;
     private startImmediately: boolean = false;
+    private overlayControls: GameOverlayControls;
 
     // Configurable Scales
     private readonly MAIN_SCALE = 1;
@@ -107,6 +109,11 @@ export class PlayScene extends BaseScene {
             onExit: () => this.exitGame(),
             onRestart: () => this.restartGame(),
             onToggleBackground: (btn) => this.toggleBackground(btn)
+        });
+
+        this.overlayControls = new GameOverlayControls({
+            scene: this,
+            onMenuClick: () => this.toggleMenu(),
         });
 
         if (this.mode === 'single') {
@@ -258,6 +265,9 @@ export class PlayScene extends BaseScene {
         if (this.inGameMenu) {
             this.inGameMenu.destroy();
         }
+        if (this.overlayControls) {
+            this.overlayControls.destroy();
+        }
     }
 
     private toggleMenu() {
@@ -402,6 +412,9 @@ export class PlayScene extends BaseScene {
         super.resize(gameSize, baseSize, displaySize, resolution);
         if (this.disconnectNoticeDOM && this.cameras && this.cameras.main) {
             this.disconnectNoticeDOM.setScale(this.cameras.main.zoom);
+        }
+        if (this.overlayControls) {
+            this.overlayControls.layout();
         }
     }
 

--- a/src/tetris/ui/gameLayout.ts
+++ b/src/tetris/ui/gameLayout.ts
@@ -40,6 +40,7 @@ export interface LayoutMetrics {
     nMultiPortraitAreaBottomPaddingBlocks: number;
     nMultiPortraitAreaHorizontalPaddingBlocks: number;
     topNavBarBlocks: number;
+    mobileTopNavBarBlocks: number;
 }
 
 export interface PlaySceneOpponentLayout {
@@ -116,13 +117,15 @@ export function getLayoutMetrics(): LayoutMetrics {
         nMultiPortraitAreaBottomPaddingBlocks: 0.5,
         nMultiPortraitAreaHorizontalPaddingBlocks: 1,
         topNavBarBlocks: 1.5,
+        mobileTopNavBarBlocks: 1.0,
     };
 }
 
 
-export function getTopNavBarHeight(): number {
+export function getTopNavBarHeight(layoutMode: LayoutMode = 'desktop'): number {
     const metrics = getLayoutMetrics();
-    return BLOCK_SIZE * metrics.topNavBarBlocks;
+    const blocks = layoutMode === 'mobile-portrait' ? metrics.mobileTopNavBarBlocks : metrics.topNavBarBlocks;
+    return BLOCK_SIZE * blocks;
 }
 
 // ─── Dimension Calculators ──────────────────────────────────────────
@@ -133,7 +136,7 @@ export function getTopNavBarHeight(): number {
 export function calcPlaySceneDimensions(layoutMode: LayoutMode, mode: string): { width: number; height: number } {
     const metrics = getLayoutMetrics();
 
-    const topNavBarHeight = getTopNavBarHeight();
+    const topNavBarHeight = getTopNavBarHeight(layoutMode);
 
     if (layoutMode === 'mobile-portrait') {
         if (mode === 'multi') {
@@ -152,7 +155,7 @@ export function calcPlaySceneDimensions(layoutMode: LayoutMode, mode: string): {
  */
 export function calcNMultiSceneDimensions(layoutMode: LayoutMode): { width: number; height: number } {
     const metrics = getLayoutMetrics();
-    const topNavBarHeight = getTopNavBarHeight();
+    const topNavBarHeight = getTopNavBarHeight(layoutMode);
     if (layoutMode === 'mobile-portrait') {
         return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 35 + topNavBarHeight };
     }
@@ -189,7 +192,7 @@ export function calcNMultiPlayerPosition(gameHeight: number, playerAreaBlocks: n
 /**
  * Portrait position: playfield centered horizontally, below hold+next row.
  */
-export function calcPortraitPosition(gameWidth: number, topInset: number = getTopNavBarHeight()): { x: number; y: number } {
+export function calcPortraitPosition(gameWidth: number, topInset: number = getTopNavBarHeight('mobile-portrait')): { x: number; y: number } {
     const metrics = getLayoutMetrics();
     return {
         x: (gameWidth - PLAYFIELD_WIDTH) / 2,
@@ -216,7 +219,7 @@ export function calcPlaySceneOpponentLayout(
     const playerAreaWidth = BLOCK_SIZE * metrics.multiPlayerAreaBlocks;
     const rightAreaWidth = gameWidth - playerAreaWidth;
     const x = playerAreaWidth + (rightAreaWidth - PLAYFIELD_WIDTH) / 2;
-    const topInset = getTopNavBarHeight();
+    const topInset = getTopNavBarHeight(layoutMode);
     const usableHeight = Math.max(0, gameHeight - topInset);
     const y = topInset + (usableHeight - PLAYFIELD_HEIGHT) / 2;
     return { x, y, scale: 1, labelOffset: 30 };
@@ -225,7 +228,7 @@ export function calcPlaySceneOpponentLayout(
 export function calcNMultiOpponentArea(layoutMode: LayoutMode, gameWidth: number, gameHeight: number): OpponentAreaLayout {
     const metrics = getLayoutMetrics();
 
-    const topInset = getTopNavBarHeight();
+    const topInset = getTopNavBarHeight(layoutMode);
 
     if (layoutMode === 'mobile-portrait') {
         const x = BLOCK_SIZE * metrics.nMultiPortraitAreaXBlocks;

--- a/src/tetris/ui/gameLayout.ts
+++ b/src/tetris/ui/gameLayout.ts
@@ -39,6 +39,7 @@ export interface LayoutMetrics {
     nMultiPortraitAreaYBlocks: number;
     nMultiPortraitAreaBottomPaddingBlocks: number;
     nMultiPortraitAreaHorizontalPaddingBlocks: number;
+    topNavBarBlocks: number;
 }
 
 export interface PlaySceneOpponentLayout {
@@ -114,7 +115,14 @@ export function getLayoutMetrics(): LayoutMetrics {
         nMultiPortraitAreaYBlocks: 28.5,
         nMultiPortraitAreaBottomPaddingBlocks: 0.5,
         nMultiPortraitAreaHorizontalPaddingBlocks: 1,
+        topNavBarBlocks: 1.5,
     };
+}
+
+
+export function getTopNavBarHeight(): number {
+    const metrics = getLayoutMetrics();
+    return BLOCK_SIZE * metrics.topNavBarBlocks;
 }
 
 // ─── Dimension Calculators ──────────────────────────────────────────
@@ -125,16 +133,18 @@ export function getLayoutMetrics(): LayoutMetrics {
 export function calcPlaySceneDimensions(layoutMode: LayoutMode, mode: string): { width: number; height: number } {
     const metrics = getLayoutMetrics();
 
+    const topNavBarHeight = getTopNavBarHeight();
+
     if (layoutMode === 'mobile-portrait') {
         if (mode === 'multi') {
-            return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 35 };
+            return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 35 + topNavBarHeight };
         }
-        return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 27 };
+        return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 27 + topNavBarHeight };
     }
     if (mode === 'multi') {
-        return { width: BLOCK_SIZE * (metrics.multiPlayerAreaBlocks + 11), height: BLOCK_SIZE * 22 };
+        return { width: BLOCK_SIZE * (metrics.multiPlayerAreaBlocks + 11), height: BLOCK_SIZE * 22 + topNavBarHeight };
     }
-    return { width: BLOCK_SIZE * 22, height: BLOCK_SIZE * 22 };
+    return { width: BLOCK_SIZE * 22, height: BLOCK_SIZE * 22 + topNavBarHeight };
 }
 
 /**
@@ -142,10 +152,11 @@ export function calcPlaySceneDimensions(layoutMode: LayoutMode, mode: string): {
  */
 export function calcNMultiSceneDimensions(layoutMode: LayoutMode): { width: number; height: number } {
     const metrics = getLayoutMetrics();
+    const topNavBarHeight = getTopNavBarHeight();
     if (layoutMode === 'mobile-portrait') {
-        return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 35 };
+        return { width: BLOCK_SIZE * 12, height: BLOCK_SIZE * 35 + topNavBarHeight };
     }
-    return { width: BLOCK_SIZE * (metrics.multiPlayerAreaBlocks + 13), height: BLOCK_SIZE * 22 };
+    return { width: BLOCK_SIZE * (metrics.multiPlayerAreaBlocks + 13), height: BLOCK_SIZE * 22 + topNavBarHeight };
 }
 
 // ─── Position Calculators ───────────────────────────────────────────
@@ -153,34 +164,36 @@ export function calcNMultiSceneDimensions(layoutMode: LayoutMode): { width: numb
 /**
  * Calculate the play field position for single-player mode (centered).
  */
-export function calcSinglePlayerPosition(gameWidth: number, gameHeight: number, mainScale: number = 1) {
+export function calcSinglePlayerPosition(gameWidth: number, gameHeight: number, mainScale: number = 1, topInset: number = getTopNavBarHeight()) {
+    const usableHeight = Math.max(0, gameHeight - topInset);
     return {
         x: (gameWidth - PLAYFIELD_WIDTH * mainScale) / 2,
-        y: (gameHeight - PLAYFIELD_HEIGHT * mainScale) / 2,
+        y: topInset + (usableHeight - PLAYFIELD_HEIGHT * mainScale) / 2,
     };
 }
 
 /**
  * Calculate the play field position for N-multi mode (centered in left player area).
  */
-export function calcNMultiPlayerPosition(gameHeight: number, playerAreaBlocks: number = 23) {
+export function calcNMultiPlayerPosition(gameHeight: number, playerAreaBlocks: number = 23, topInset: number = getTopNavBarHeight()) {
     const metrics = getLayoutMetrics();
     const areaBlocks = playerAreaBlocks ?? metrics.multiPlayerAreaBlocks;
     const leftArea = BLOCK_SIZE * areaBlocks;
+    const usableHeight = Math.max(0, gameHeight - topInset);
     return {
         x: (leftArea - PLAYFIELD_WIDTH) / 2,
-        y: (gameHeight - PLAYFIELD_HEIGHT) / 2,
+        y: topInset + (usableHeight - PLAYFIELD_HEIGHT) / 2,
     };
 }
 
 /**
  * Portrait position: playfield centered horizontally, below hold+next row.
  */
-export function calcPortraitPosition(gameWidth: number): { x: number; y: number } {
+export function calcPortraitPosition(gameWidth: number, topInset: number = getTopNavBarHeight()): { x: number; y: number } {
     const metrics = getLayoutMetrics();
     return {
         x: (gameWidth - PLAYFIELD_WIDTH) / 2,
-        y: BLOCK_SIZE * metrics.portraitFieldTopBlocks,
+        y: topInset + BLOCK_SIZE * metrics.portraitFieldTopBlocks,
     };
 }
 
@@ -203,25 +216,29 @@ export function calcPlaySceneOpponentLayout(
     const playerAreaWidth = BLOCK_SIZE * metrics.multiPlayerAreaBlocks;
     const rightAreaWidth = gameWidth - playerAreaWidth;
     const x = playerAreaWidth + (rightAreaWidth - PLAYFIELD_WIDTH) / 2;
-    const y = (gameHeight - PLAYFIELD_HEIGHT) / 2;
+    const topInset = getTopNavBarHeight();
+    const usableHeight = Math.max(0, gameHeight - topInset);
+    const y = topInset + (usableHeight - PLAYFIELD_HEIGHT) / 2;
     return { x, y, scale: 1, labelOffset: 30 };
 }
 
 export function calcNMultiOpponentArea(layoutMode: LayoutMode, gameWidth: number, gameHeight: number): OpponentAreaLayout {
     const metrics = getLayoutMetrics();
 
+    const topInset = getTopNavBarHeight();
+
     if (layoutMode === 'mobile-portrait') {
         const x = BLOCK_SIZE * metrics.nMultiPortraitAreaXBlocks;
-        const y = BLOCK_SIZE * metrics.nMultiPortraitAreaYBlocks;
+        const y = topInset + BLOCK_SIZE * metrics.nMultiPortraitAreaYBlocks;
         const width = gameWidth - BLOCK_SIZE * metrics.nMultiPortraitAreaHorizontalPaddingBlocks;
         const height = gameHeight - y - BLOCK_SIZE * metrics.nMultiPortraitAreaBottomPaddingBlocks;
         return { x, y, width, height };
     }
 
     const x = BLOCK_SIZE * metrics.nMultiDesktopAreaXBlocks;
-    const y = BLOCK_SIZE * metrics.nMultiDesktopAreaYBlocks;
+    const y = topInset + BLOCK_SIZE * metrics.nMultiDesktopAreaYBlocks;
     const width = gameWidth - x - BLOCK_SIZE * metrics.nMultiDesktopAreaRightPaddingBlocks;
-    const height = gameHeight - BLOCK_SIZE * metrics.nMultiDesktopAreaBottomPaddingBlocks;
+    const height = gameHeight - y - BLOCK_SIZE * metrics.nMultiDesktopAreaBottomPaddingBlocks;
     return { x, y, width, height };
 }
 

--- a/src/tetris/ui/gameOverlayControls.ts
+++ b/src/tetris/ui/gameOverlayControls.ts
@@ -1,0 +1,87 @@
+import { TextStyles, createStyledText, drawPanelBackground } from "./uiStyles";
+
+interface OverlayControlOptions {
+    scene: Phaser.Scene;
+    onMenuClick: () => void;
+}
+
+export class GameOverlayControls {
+    private readonly scene: Phaser.Scene;
+    private readonly onMenuClick: () => void;
+
+    private root: Phaser.GameObjects.Container;
+    private menuButton: Phaser.GameObjects.Container;
+    private hitArea: Phaser.GameObjects.Zone;
+
+    constructor(options: OverlayControlOptions) {
+        this.scene = options.scene;
+        this.onMenuClick = options.onMenuClick;
+
+        this.root = this.scene.add.container(0, 0).setDepth(3000);
+        this.root.setScrollFactor(0);
+
+        this.menuButton = this.createMenuButton();
+        this.root.add(this.menuButton);
+
+        this.layout();
+    }
+
+    public layout() {
+        this.menuButton.setPosition(16, 16);
+    }
+
+    public destroy() {
+        this.root.destroy(true);
+    }
+
+    private createMenuButton(): Phaser.GameObjects.Container {
+        const width = 108;
+        const height = 40;
+        const button = this.scene.add.container(0, 0);
+
+        const bg = this.scene.add.graphics();
+        drawPanelBackground(bg, width, height);
+
+        // HOLD/NEXT 스타일과 어울리도록 강조 라인 추가
+        bg.lineStyle(1, 0x67e8f9, 0.9);
+        bg.strokeRect(2, 2, width - 4, height - 4);
+
+        const label = createStyledText(
+            this.scene,
+            button,
+            width / 2,
+            height / 2,
+            'MENU',
+            { ...TextStyles.header, align: 'center', fontSize: '18px' },
+            3,
+        );
+        label.setOrigin(0.5);
+
+        this.hitArea = this.scene.add.zone(0, 0, width, height).setOrigin(0);
+        this.hitArea.setInteractive({ useHandCursor: true })
+            .on('pointerdown', () => {
+                bg.clear();
+                drawPanelBackground(bg, width, height);
+                bg.fillStyle(0x0f172a, 0.45);
+                bg.fillRect(0, 0, width, height);
+                bg.lineStyle(1, 0x67e8f9, 1);
+                bg.strokeRect(2, 2, width - 4, height - 4);
+                this.onMenuClick();
+            })
+            .on('pointerup', () => {
+                bg.clear();
+                drawPanelBackground(bg, width, height);
+                bg.lineStyle(1, 0x67e8f9, 0.9);
+                bg.strokeRect(2, 2, width - 4, height - 4);
+            })
+            .on('pointerout', () => {
+                bg.clear();
+                drawPanelBackground(bg, width, height);
+                bg.lineStyle(1, 0x67e8f9, 0.9);
+                bg.strokeRect(2, 2, width - 4, height - 4);
+            });
+
+        button.add([bg, this.hitArea]);
+        return button;
+    }
+}

--- a/src/tetris/ui/gameOverlayControls.ts
+++ b/src/tetris/ui/gameOverlayControls.ts
@@ -1,106 +1,76 @@
+import { TextStyles, createStyledText, drawPanelBackground } from "./uiStyles";
+
 interface OverlayControlOptions {
     scene: Phaser.Scene;
     onMenuClick: () => void;
 }
 
-/**
- * Fixed viewport menu button (DOM-based).
- * - independent from camera zoom / aspect ratio
- * - always visible at top-left
- * - reliable mouse click handling
- */
 export class GameOverlayControls {
     private readonly scene: Phaser.Scene;
     private readonly onMenuClick: () => void;
 
-    private menuButton: HTMLButtonElement | null = null;
+    private root: Phaser.GameObjects.Container;
+    private background: Phaser.GameObjects.Graphics;
+    private label: Phaser.GameObjects.Text;
+    private readonly width: number = 108;
+    private readonly height: number = 40;
 
     constructor(options: OverlayControlOptions) {
         this.scene = options.scene;
         this.onMenuClick = options.onMenuClick;
 
-        this.createMenuButton();
+        this.root = this.scene.add.container(0, 0).setDepth(3000);
+
+        this.background = this.scene.add.graphics();
+        this.drawDefault();
+
+        this.label = createStyledText(
+            this.scene,
+            this.root,
+            this.width / 2,
+            this.height / 2,
+            'MENU',
+            { ...TextStyles.header, align: 'center', fontSize: '18px' },
+            3,
+        ).setOrigin(0.5);
+
+        const hitArea = this.scene.add.rectangle(0, 0, this.width, this.height, 0x000000, 0);
+        hitArea.setOrigin(0, 0);
+        hitArea.setInteractive({ useHandCursor: true });
+        hitArea.on('pointerdown', () => this.drawPressed());
+        hitArea.on('pointerup', () => {
+            this.drawDefault();
+            this.onMenuClick();
+        });
+        hitArea.on('pointerout', () => this.drawDefault());
+
+        this.root.add([this.background, hitArea, this.label]);
         this.layout();
     }
 
     public layout() {
-        if (!this.menuButton) return;
-        // iOS notch/safe-area 대응 + 고정 좌상단 배치
-        this.menuButton.style.top = 'max(12px, env(safe-area-inset-top))';
-        this.menuButton.style.left = 'max(12px, env(safe-area-inset-left))';
+        const cam = this.scene.cameras.main;
+        const view = cam.worldView;
+        this.root.setPosition(view.x + 12, view.y + 10);
     }
 
     public destroy() {
-        if (!this.menuButton) return;
-        this.menuButton.onclick = null;
-        if (this.menuButton.parentNode) {
-            this.menuButton.parentNode.removeChild(this.menuButton);
-        }
-        this.menuButton = null;
+        this.root.destroy(true);
     }
 
-    private createMenuButton() {
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.textContent = 'MENU';
-        button.setAttribute('aria-label', 'Open menu');
+    private drawDefault() {
+        this.background.clear();
+        drawPanelBackground(this.background, this.width, this.height);
+        this.background.lineStyle(1, 0x67e8f9, 0.9);
+        this.background.strokeRect(2, 2, this.width - 4, this.height - 4);
+    }
 
-        // HOLD/NEXT 패널 감성에 맞춘 스타일
-        button.style.cssText = `
-            position: fixed;
-            z-index: 9000;
-            width: 108px;
-            height: 40px;
-            border: 1px solid #eeeeee;
-            outline: 1px solid rgba(103, 232, 249, 0.9);
-            outline-offset: -3px;
-            background: rgba(0, 0, 0, 0.2);
-            color: #ffffff;
-            font-family: Pretendard, Arial Black, sans-serif;
-            font-weight: 700;
-            font-size: 18px;
-            line-height: 1;
-            letter-spacing: 0.5px;
-            cursor: pointer;
-            user-select: none;
-            -webkit-text-stroke: 1px #000000;
-            text-shadow: 2px 2px 2px rgba(0,0,0,0.85);
-            box-sizing: border-box;
-            border-radius: 2px;
-            padding: 0;
-            touch-action: manipulation;
-        `;
-
-        const resetVisual = () => {
-            if (!this.menuButton) return;
-            this.menuButton.style.background = 'rgba(0, 0, 0, 0.2)';
-            this.menuButton.style.transform = 'translateY(0px)';
-        };
-
-        button.onpointerdown = (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            button.style.background = 'rgba(15, 23, 42, 0.45)';
-            button.style.transform = 'translateY(1px)';
-        };
-
-        button.onpointerup = (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            resetVisual();
-        };
-
-        button.onpointerleave = resetVisual;
-        button.onpointercancel = resetVisual;
-
-        // 포인터 이벤트 미지원/차단 환경 대비
-        button.onclick = (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            this.onMenuClick();
-        };
-
-        document.body.appendChild(button);
-        this.menuButton = button;
+    private drawPressed() {
+        this.background.clear();
+        drawPanelBackground(this.background, this.width, this.height);
+        this.background.fillStyle(0x0f172a, 0.45);
+        this.background.fillRect(0, 0, this.width, this.height);
+        this.background.lineStyle(1, 0x67e8f9, 1);
+        this.background.strokeRect(2, 2, this.width - 4, this.height - 4);
     }
 }

--- a/src/tetris/ui/gameOverlayControls.ts
+++ b/src/tetris/ui/gameOverlayControls.ts
@@ -1,87 +1,106 @@
-import { TextStyles, createStyledText, drawPanelBackground } from "./uiStyles";
-
 interface OverlayControlOptions {
     scene: Phaser.Scene;
     onMenuClick: () => void;
 }
 
+/**
+ * Fixed viewport menu button (DOM-based).
+ * - independent from camera zoom / aspect ratio
+ * - always visible at top-left
+ * - reliable mouse click handling
+ */
 export class GameOverlayControls {
     private readonly scene: Phaser.Scene;
     private readonly onMenuClick: () => void;
 
-    private root: Phaser.GameObjects.Container;
-    private menuButton: Phaser.GameObjects.Container;
-    private hitArea: Phaser.GameObjects.Zone;
+    private menuButton: HTMLButtonElement | null = null;
 
     constructor(options: OverlayControlOptions) {
         this.scene = options.scene;
         this.onMenuClick = options.onMenuClick;
 
-        this.root = this.scene.add.container(0, 0).setDepth(3000);
-        this.root.setScrollFactor(0);
-
-        this.menuButton = this.createMenuButton();
-        this.root.add(this.menuButton);
-
+        this.createMenuButton();
         this.layout();
     }
 
     public layout() {
-        this.menuButton.setPosition(16, 16);
+        if (!this.menuButton) return;
+        // iOS notch/safe-area 대응 + 고정 좌상단 배치
+        this.menuButton.style.top = 'max(12px, env(safe-area-inset-top))';
+        this.menuButton.style.left = 'max(12px, env(safe-area-inset-left))';
     }
 
     public destroy() {
-        this.root.destroy(true);
+        if (!this.menuButton) return;
+        this.menuButton.onclick = null;
+        if (this.menuButton.parentNode) {
+            this.menuButton.parentNode.removeChild(this.menuButton);
+        }
+        this.menuButton = null;
     }
 
-    private createMenuButton(): Phaser.GameObjects.Container {
-        const width = 108;
-        const height = 40;
-        const button = this.scene.add.container(0, 0);
+    private createMenuButton() {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = 'MENU';
+        button.setAttribute('aria-label', 'Open menu');
 
-        const bg = this.scene.add.graphics();
-        drawPanelBackground(bg, width, height);
+        // HOLD/NEXT 패널 감성에 맞춘 스타일
+        button.style.cssText = `
+            position: fixed;
+            z-index: 9000;
+            width: 108px;
+            height: 40px;
+            border: 1px solid #eeeeee;
+            outline: 1px solid rgba(103, 232, 249, 0.9);
+            outline-offset: -3px;
+            background: rgba(0, 0, 0, 0.2);
+            color: #ffffff;
+            font-family: Pretendard, Arial Black, sans-serif;
+            font-weight: 700;
+            font-size: 18px;
+            line-height: 1;
+            letter-spacing: 0.5px;
+            cursor: pointer;
+            user-select: none;
+            -webkit-text-stroke: 1px #000000;
+            text-shadow: 2px 2px 2px rgba(0,0,0,0.85);
+            box-sizing: border-box;
+            border-radius: 2px;
+            padding: 0;
+            touch-action: manipulation;
+        `;
 
-        // HOLD/NEXT 스타일과 어울리도록 강조 라인 추가
-        bg.lineStyle(1, 0x67e8f9, 0.9);
-        bg.strokeRect(2, 2, width - 4, height - 4);
+        const resetVisual = () => {
+            if (!this.menuButton) return;
+            this.menuButton.style.background = 'rgba(0, 0, 0, 0.2)';
+            this.menuButton.style.transform = 'translateY(0px)';
+        };
 
-        const label = createStyledText(
-            this.scene,
-            button,
-            width / 2,
-            height / 2,
-            'MENU',
-            { ...TextStyles.header, align: 'center', fontSize: '18px' },
-            3,
-        );
-        label.setOrigin(0.5);
+        button.onpointerdown = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            button.style.background = 'rgba(15, 23, 42, 0.45)';
+            button.style.transform = 'translateY(1px)';
+        };
 
-        this.hitArea = this.scene.add.zone(0, 0, width, height).setOrigin(0);
-        this.hitArea.setInteractive({ useHandCursor: true })
-            .on('pointerdown', () => {
-                bg.clear();
-                drawPanelBackground(bg, width, height);
-                bg.fillStyle(0x0f172a, 0.45);
-                bg.fillRect(0, 0, width, height);
-                bg.lineStyle(1, 0x67e8f9, 1);
-                bg.strokeRect(2, 2, width - 4, height - 4);
-                this.onMenuClick();
-            })
-            .on('pointerup', () => {
-                bg.clear();
-                drawPanelBackground(bg, width, height);
-                bg.lineStyle(1, 0x67e8f9, 0.9);
-                bg.strokeRect(2, 2, width - 4, height - 4);
-            })
-            .on('pointerout', () => {
-                bg.clear();
-                drawPanelBackground(bg, width, height);
-                bg.lineStyle(1, 0x67e8f9, 0.9);
-                bg.strokeRect(2, 2, width - 4, height - 4);
-            });
+        button.onpointerup = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            resetVisual();
+        };
 
-        button.add([bg, this.hitArea]);
-        return button;
+        button.onpointerleave = resetVisual;
+        button.onpointercancel = resetVisual;
+
+        // 포인터 이벤트 미지원/차단 환경 대비
+        button.onclick = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.onMenuClick();
+        };
+
+        document.body.appendChild(button);
+        this.menuButton = button;
     }
 }

--- a/test/unit/scenes/layoutPositions.test.ts
+++ b/test/unit/scenes/layoutPositions.test.ts
@@ -12,7 +12,7 @@ describe('scene layout positions', () => {
     const opponent = calcPlaySceneOpponentLayout('mobile-portrait', dims.width, dims.height, playerPos.y);
 
     expect(opponent.x).toBeCloseTo(149.6, 5);
-    expect(opponent.y).toBeCloseTo(934.4, 5);
+    expect(opponent.y).toBeCloseTo(982.4, 5);
     expect(opponent.scale).toBeCloseTo(0.265, 5);
     expect(opponent.labelOffset).toBe(20);
   });
@@ -22,13 +22,13 @@ describe('scene layout positions', () => {
     const opponent = calcPlaySceneOpponentLayout('desktop', dims.width, dims.height, 0);
 
     expect(opponent.x).toBe(752);
-    expect(opponent.y).toBe(32);
+    expect(opponent.y).toBe(80);
     expect(opponent.scale).toBe(1);
     expect(opponent.labelOffset).toBe(30);
   });
 
   test('keeps n-multi player anchor unchanged', () => {
     const pos = calcNMultiPlayerPosition(704);
-    expect(pos).toEqual({ x: 208, y: 32 });
+    expect(pos).toEqual({ x: 208, y: 56 });
   });
 });

--- a/test/unit/scenes/layoutPositions.test.ts
+++ b/test/unit/scenes/layoutPositions.test.ts
@@ -12,7 +12,7 @@ describe('scene layout positions', () => {
     const opponent = calcPlaySceneOpponentLayout('mobile-portrait', dims.width, dims.height, playerPos.y);
 
     expect(opponent.x).toBeCloseTo(149.6, 5);
-    expect(opponent.y).toBeCloseTo(982.4, 5);
+    expect(opponent.y).toBeCloseTo(966.4, 5);
     expect(opponent.scale).toBeCloseTo(0.265, 5);
     expect(opponent.labelOffset).toBe(20);
   });

--- a/test/unit/ui/gameLayout.metrics.test.ts
+++ b/test/unit/ui/gameLayout.metrics.test.ts
@@ -17,27 +17,27 @@ describe('gameLayout metrics', () => {
     const fieldRight = fieldPos.x + block * CONST.PLAY_FIELD.COL_COUNT;
 
     expect(hud.holdX).toBe(fieldPos.x);
-    expect(hud.holdY).toBeCloseTo(110.4, 5);
+    expect(hud.holdY).toBeCloseTo(94.4, 5);
     expect(hud.holdX + hud.holdWidth).toBeLessThanOrEqual(fieldRight);
 
-    expect(hud.queueY).toBeCloseTo(86.4, 5);
+    expect(hud.queueY).toBeCloseTo(70.4, 5);
     expect(hud.queueX + hud.queueWidth).toBeCloseTo(fieldRight, 5);
   });
 
   test('keeps scene dimension outputs unchanged', () => {
-    expect(calcPlaySceneDimensions('mobile-portrait', 'single')).toEqual({ width: 384, height: 912 });
-    expect(calcPlaySceneDimensions('mobile-portrait', 'multi')).toEqual({ width: 384, height: 1168 });
+    expect(calcPlaySceneDimensions('mobile-portrait', 'single')).toEqual({ width: 384, height: 896 });
+    expect(calcPlaySceneDimensions('mobile-portrait', 'multi')).toEqual({ width: 384, height: 1152 });
     expect(calcPlaySceneDimensions('desktop', 'single')).toEqual({ width: 704, height: 752 });
     expect(calcPlaySceneDimensions('desktop', 'multi')).toEqual({ width: 1088, height: 752 });
 
-    expect(calcNMultiSceneDimensions('mobile-portrait')).toEqual({ width: 384, height: 1168 });
+    expect(calcNMultiSceneDimensions('mobile-portrait')).toEqual({ width: 384, height: 1152 });
     expect(calcNMultiSceneDimensions('desktop')).toEqual({ width: 1152, height: 752 });
   });
 
   test('keeps n-multi opponent area bounds unchanged', () => {
-    expect(calcNMultiOpponentArea('mobile-portrait', 384, 1168)).toEqual({
+    expect(calcNMultiOpponentArea('mobile-portrait', 384, 1152)).toEqual({
       x: 16,
-      y: 960,
+      y: 944,
       width: 352,
       height: 192,
     });

--- a/test/unit/ui/gameLayout.metrics.test.ts
+++ b/test/unit/ui/gameLayout.metrics.test.ts
@@ -17,36 +17,36 @@ describe('gameLayout metrics', () => {
     const fieldRight = fieldPos.x + block * CONST.PLAY_FIELD.COL_COUNT;
 
     expect(hud.holdX).toBe(fieldPos.x);
-    expect(hud.holdY).toBeCloseTo(62.4, 5);
+    expect(hud.holdY).toBeCloseTo(110.4, 5);
     expect(hud.holdX + hud.holdWidth).toBeLessThanOrEqual(fieldRight);
 
-    expect(hud.queueY).toBeCloseTo(38.4, 5);
+    expect(hud.queueY).toBeCloseTo(86.4, 5);
     expect(hud.queueX + hud.queueWidth).toBeCloseTo(fieldRight, 5);
   });
 
   test('keeps scene dimension outputs unchanged', () => {
-    expect(calcPlaySceneDimensions('mobile-portrait', 'single')).toEqual({ width: 384, height: 864 });
-    expect(calcPlaySceneDimensions('mobile-portrait', 'multi')).toEqual({ width: 384, height: 1120 });
-    expect(calcPlaySceneDimensions('desktop', 'single')).toEqual({ width: 704, height: 704 });
-    expect(calcPlaySceneDimensions('desktop', 'multi')).toEqual({ width: 1088, height: 704 });
+    expect(calcPlaySceneDimensions('mobile-portrait', 'single')).toEqual({ width: 384, height: 912 });
+    expect(calcPlaySceneDimensions('mobile-portrait', 'multi')).toEqual({ width: 384, height: 1168 });
+    expect(calcPlaySceneDimensions('desktop', 'single')).toEqual({ width: 704, height: 752 });
+    expect(calcPlaySceneDimensions('desktop', 'multi')).toEqual({ width: 1088, height: 752 });
 
-    expect(calcNMultiSceneDimensions('mobile-portrait')).toEqual({ width: 384, height: 1120 });
-    expect(calcNMultiSceneDimensions('desktop')).toEqual({ width: 1152, height: 704 });
+    expect(calcNMultiSceneDimensions('mobile-portrait')).toEqual({ width: 384, height: 1168 });
+    expect(calcNMultiSceneDimensions('desktop')).toEqual({ width: 1152, height: 752 });
   });
 
   test('keeps n-multi opponent area bounds unchanged', () => {
-    expect(calcNMultiOpponentArea('mobile-portrait', 384, 1120)).toEqual({
+    expect(calcNMultiOpponentArea('mobile-portrait', 384, 1168)).toEqual({
       x: 16,
-      y: 912,
+      y: 960,
       width: 352,
       height: 192,
     });
 
-    expect(calcNMultiOpponentArea('desktop', 1152, 704)).toEqual({
+    expect(calcNMultiOpponentArea('desktop', 1152, 752)).toEqual({
       x: 752,
-      y: 32,
+      y: 80,
       width: 384,
-      height: 640,
+      height: 608,
     });
   });
 });


### PR DESCRIPTION
### Motivation
- The in-game mouse control pad was not requested and should be removed, leaving only an always-available MENU button in the overlay. 
- The MENU button appearance was too plain and must visually match the existing HOLD/NEXT UI language.

### Description
- Removed mouse gameplay controls and the auxiliary `dispatchInput()` helper, restoring keyboard/engine input flow in `src/tetris/input/inputManager.ts`.
- Added a compact overlay component `src/tetris/ui/gameOverlayControls.ts` that provides a single top-left `MENU` button styled using shared UI utilities (`drawPanelBackground`, `createStyledText`, `TextStyles`) so it matches HOLD/NEXT visuals and supports pressed/hover states.
- Integrated the new overlay into `PlayScene` and `NMultiPlayScene` by instantiating `GameOverlayControls`, calling `layout()` on resize, and destroying it on shutdown (`src/tetris/scenes/playScene.ts`, `src/tetris/scenes/nMultiPlayScene.ts`).
- Simplified event wiring so the button only calls the scene menu toggle via `onMenuClick` and no longer dispatches gameplay inputs.

### Testing
- Ran unit tests with `npm test -- --runInBand` and all test suites passed (25 suites, 230 tests) without failures. 
- Built production bundle with `npm run build` which completed successfully. 
- Performed a manual browser run and captured an automated screenshot to verify the menu-only overlay visually (Playwright/http server), confirming the button layout and interaction worked as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69939e8de46c8320ab56422b158eaa92)