### PR TITLE
Fix accidental hard drop during fast horizontal swipes on mobile

### DIFF
--- a/src/tetris/input/inputManager.ts
+++ b/src/tetris/input/inputManager.ts
@@ -139,8 +139,9 @@ export class InputManager {
                     this.scene.time.delayedCall(100, () => this.emitInput('clockwise', InputState.RELEASE));
                 }
             } else {
-                // Check Hard Drop (Flick)
-                if (duration < 300 && deltaY > 50) {
+                // Check Hard Drop (Flick) - require primarily vertical swipe
+                const deltaX = Math.abs(pointer.worldX - this.touchStartX);
+                if (duration < 300 && deltaY > 50 && deltaX < 30 && deltaY > deltaX * 2) {
                     this.emitInput('hardDrop', InputState.PRESS);
                     this.scene.time.delayedCall(100, () => this.emitInput('hardDrop', InputState.RELEASE));
                 }


### PR DESCRIPTION
Add horizontal displacement threshold (< 30px) and vertical-to-horizontal
ratio check (deltaY > deltaX * 2) to hard drop detection. This prevents
hard drops from triggering when the player quickly swipes sideways to
move a piece, which often produces slight diagonal finger movement.

https://claude.ai/code/session_01NSGgQXLgZQJu4fJbzYWrQJ