### PR TITLE
Implement guideline fixes: engine phase tracking, lock-reset boundary, and line-count level progression

### DIFF
--- a/docs/2009-guideline-gap-plan.md
+++ b/docs/2009-guideline-gap-plan.md
@@ -1,0 +1,146 @@
+# 2009 Tetris Design Guideline 갭 분석 및 수정 계획
+
+## 범위
+- 기준 문서: `2009 Tetris Design Guideline.md`
+- 추가 참고: Appendix A `The Tetris Engine` 플로우차트(Generation → Falling → Lock → Pattern → Iterate → Animate → Eliminate → Completion)
+- 점검 대상: 핵심 규칙 구현(`const`, `scoreSystem`, `playField`, `inputManager`, `engine`, `ui/gameLayout`)
+
+## 요약
+- **즉시 수정 필요(우선순위 상)**
+  1. Extended Placement(락다운 리셋) 횟수 오프바이원
+  2. 레벨업 계산식이 가이드의 "실제 라인 수 기반"과 다름
+  3. DAS/ARR 값이 가이드 권장(~0.3s DAS, 전체 횡이동 약 0.5s) 대비 빠름
+- **엔진 관점 보완 필요(우선순위 중)**
+  4. Appendix A 단계를 코드에서 명시적 상태로 관리하지 않아 검증/디버깅 추적성이 약함
+  5. Pattern/Iterate/Animate/Eliminate/Completion 단계 전이 테스트가 부족함
+- **정책 결정 필요(우선순위 중)**
+  6. 레벨 상한(1~15) 강제 여부
+
+---
+
+## 항목별 분석
+
+### 1) Matrix / Buffer Zone
+- **가이드 요구**: 보이는 20행 + 숨김 20행(총 40행).
+- **현재 구현**: 유효 row 범위를 `[-20, 19]`로 허용.
+- **판정**: ✅ 충족.
+
+### 2) Spawn 위치/방향/즉시 1칸 낙하
+- **가이드 요구**: 북쪽 방향 스폰, 중앙 정렬, 생성 직후 아래가 비어 있으면 즉시 1칸 낙하.
+- **현재 구현**:
+  - 스폰 기본 위치 `col=3`, `row=-2` (0-index 기준 가이드 중앙 정렬과 일치)
+  - 생성 직후 `moveDown('autoDrop')` 실행
+- **판정**: ✅ 충족.
+
+### 3) 7-Bag 랜덤
+- **가이드 요구**: 7-Bag 사용.
+- **현재 구현**: `TetrominoBoxQueue` 기반 7개 유니크 사이클을 전제로 테스트 존재.
+- **판정**: ✅ 충족.
+
+### 4) Lock Down (Extended Placement)
+- **가이드 요구**: 착지 후 0.5초, 이동/회전 시 리셋, **같은 높이에서 최대 15회 리셋 허용**.
+- **현재 구현**:
+  - `LOCK_DELAY_MS = 500`
+  - `manipulationCount < 15`일 때만 타이머 재시작
+- **갭**: 현재 조건이면 리셋이 14회까지만 허용되는 형태가 되어 **오프바이원 가능성**이 큼.
+- **판정**: ⚠️ 부분 충족.
+
+### 5) Gravity / Soft Drop / Hard Drop
+- **가이드 요구**:
+  - 중력: 레벨 공식 기반
+  - Soft Drop: 현재 중력의 20배
+  - Hard Drop: 즉시 락
+- **현재 구현**:
+  - 중력 지연: `Math.pow((0.8 - ((level - 1) * 0.007)), (level - 1)) * 1000`
+  - Soft Drop: 씬에서 `autoDropDelay / 20`로 입력 반복 설정
+  - Hard Drop: `hardDrop()` 후 즉시 `lock()`
+- **판정**: ✅ 충족.
+
+### 6) DAS
+- **가이드 요구**: 좌우 홀드 시 약 0.3초 대기 후, 전체 가로 이동이 약 0.5초 수준.
+- **현재 구현**: `DAS_MS = 183`, `AR_MS = 50`.
+- **갭**: 가이드 권장 체감보다 빠른 세팅.
+- **판정**: ⚠️ 부분 충족(튜닝 필요).
+
+### 7) Scoring / B2B / T-Spin
+- **가이드 요구**: 기본 점수표 및 B2B, 3-corner T-Spin 판정.
+- **현재 구현**: 점수표/배수/B2B/T-Spin 코너 판정 모두 존재.
+- **판정**: ✅ 충족.
+
+### 8) Level Up
+- **가이드 요구**: 레벨업은 실제 라인 클리어 누적으로 관리(레벨*5 목표), 1~15 레벨 체계.
+- **현재 구현**:
+  - 레벨 목표 증가 로직은 존재
+  - 그러나 `LINE_COUNT`(Single=1, Double=3, Triple=5, Tetris=8 ...)를 누적하여 레벨 계산
+- **갭**: 실제 클리어 라인 수(1/2/3/4)가 아닌 가중치 라인으로 레벨업이 진행되어 가이드와 불일치.
+- **판정**: ❌ 미충족.
+
+### 9) UI (Next/Hold/Stats)
+- **가이드 요구**: Next 1~6, Hold, Score/Level/Lines 표기.
+- **현재 구현**:
+  - 데스크톱 Next=6, 모바일 portrait Next=1
+  - Hold/Stats 패널 존재
+- **판정**: ✅ 충족.
+
+### 10) Appendix A 엔진 플로우(Generation/Falling/Lock/Pattern/Iterate/Animate/Eliminate/Completion)
+- **가이드 요구**: 조작 가능한 테트리미노는 항상 1개이며, 각 피스가 엔진 8단계를 순차적으로 통과.
+- **현재 구현 매핑**:
+  - Generation/Falling/Lock: `spawnTetromino`, `autoDrop`, `startLockTimer`/`lock`로 동작
+  - Pattern/Iterate/Animate/Eliminate: `getClearedRows` → `playClearAnimation` → `clearRows`
+  - Completion: lock 이벤트 emit 후 ARE 지연 뒤 다음 스폰
+- **평가**:
+  - 동작 자체는 플로우와 **대체로 정합**
+  - 다만 phase 상태를 enum/state-machine으로 명시하지 않아 단계 전이 검증이 어렵고, 회귀 시 문제 추적성이 낮음
+- **판정**: ⚠️ 동작 정합 / 구조적 추적성 미흡.
+
+---
+
+## 수정 계획
+
+## Phase 1 — 규칙 정합성 우선 (1~2일)
+1. **Extended Placement 리셋 카운트 정확화**
+   - 목표: 같은 높이에서 정확히 15회까지 리셋 허용, 16회째부터 불가.
+   - 조치: `setLockTimer`의 조건식과 `manipulationCount` 증가 타이밍을 테스트로 고정.
+   - 검증: 경계값(14/15/16) 단위 테스트 추가.
+
+2. **레벨업 계산을 실제 클리어 라인 기반으로 전환**
+   - 목표: Single/Double/Triple/Tetris가 각각 1/2/3/4 라인으로 누적.
+   - 조치: `GameRules.getLineCount` 경로 제거 또는 레벨용 라인 계산 분리.
+   - 검증: 레벨업 시나리오 테스트(예: 5라인/15라인/누적 초과 케이스) 추가.
+
+## Phase 2 — 엔진 플로우 가시성/검증 강화 (0.5~1일)
+3. **Appendix A phase 상태 명시화**
+   - 목표: 최소한 디버그 모드에서 현재 phase를 명시적으로 추적 가능하게 구성.
+   - 조치: `PlayField` 또는 `Engine`에 phase enum(`Generation`, `Falling`, `Lock`, `Pattern`, `Iterate`, `Animate`, `Eliminate`, `Completion`) 추가.
+   - 검증: phase 전이 순서 단위 테스트(하드드롭/일반락/라인클리어 유무 분기) 작성.
+
+4. **Pattern→Iterate→Animate→Eliminate→Completion 전이 회귀 테스트 보강**
+   - 목표: 라인 클리어 있는 경우/없는 경우 모두 phase 순서가 안정적으로 유지.
+   - 조치: `guideline.test.ts` 또는 신규 `engine_flow.test.ts`에서 이벤트/호출 순서 캡처.
+   - 검증: CI에서 phase sequence snapshot 또는 ordered assertion 통과.
+
+## Phase 3 — 조작감 가이드 정렬 (0.5~1일)
+5. **DAS/ARR 튜닝값 가이드 프로파일 추가**
+   - 목표: 기본값을 가이드 권장(약 DAS 300ms, 횡이동 체감 0.5s)에 맞춤.
+   - 조치: `CONST.PLAY_FIELD`에 프로파일(legacy/current/guideline) 도입 혹은 설정값화.
+   - 검증: 입력 반복 간격 단위 테스트 + 플레이 테스트 체크리스트 작성.
+
+## Phase 4 — 정책 확정 (0.5일)
+6. **레벨 상한(15) 적용 여부 결정**
+   - 목표: 가이드 모드에서는 15 상한 강제.
+   - 조치: 옵션 플래그(`guidelineStrict`)로 상한 on/off.
+   - 검증: 15레벨 도달 후 속도/목표값 고정 여부 테스트.
+
+---
+
+## 권장 구현 순서
+1) 레벨업 계산 정합성 수정
+2) 락다운 15회 경계값 수정
+3) 엔진 phase 명시화 + 전이 테스트 추가
+4) DAS/ARR 가이드 프로파일 반영
+5) 레벨 15 상한 정책 반영
+
+## 완료 정의(DoD)
+- 가이드 핵심 항목(스폰/회전/락다운/점수/레벨/입력/엔진 phase) 관련 테스트가 모두 녹색.
+- `guideline.test.ts`(또는 `engine_flow.test.ts`)에 레벨업/락다운 경계/phase 전이 케이스 보강.
+- 기본 모드와 가이드 엄격 모드(있다면)의 동작 차이가 문서화됨.

--- a/src/tetris/logic/scoreSystem.ts
+++ b/src/tetris/logic/scoreSystem.ts
@@ -151,11 +151,9 @@ export class ScoreSystem {
 
         this.score += scoreAdded;
 
-        // Calculate Level
-        if (actionName) {
-            let lineCount = GameRules.getLineCount(actionName);
-            if (isBackToBackBonus) lineCount = Math.ceil(lineCount * 1.5);
-            this.addLineCount(lineCount);
+        // Calculate Level by actual cleared lines (Guideline: line-clear accumulation)
+        if (clearedLineCount > 0) {
+            this.addLineCount(clearedLineCount);
         }
 
         // Calculate Garbage

--- a/src/tetris/objects/playField.ts
+++ b/src/tetris/objects/playField.ts
@@ -18,6 +18,18 @@ const TYPE_TO_CHAR: Record<string, string> = {
     [TetrominoType.GARBAGE]: 'G',
 };
 
+
+
+export enum EnginePhase {
+    GENERATION = 'Generation',
+    FALLING = 'Falling',
+    LOCK = 'Lock',
+    PATTERN = 'Pattern',
+    ITERATE = 'Iterate',
+    ANIMATE = 'Animate',
+    ELIMINATE = 'Eliminate',
+    COMPLETION = 'Completion',
+}
 /**
  * Play field
  */
@@ -33,6 +45,7 @@ export class PlayField extends ObjectBase {
     private effects: PlayFieldEffects;
     private pendingClearedRows: number[] | null = null;
     private inactiveBlocksCache: ColRow[] | null = null;
+    private currentPhase: EnginePhase = EnginePhase.COMPLETION;
 
     public get activeTetrominoInstance(): Tetromino {
         return this.activeTetromino;
@@ -40,6 +53,16 @@ export class PlayField extends ObjectBase {
 
     public get canHoldFlag(): boolean {
         return this.canHold;
+    }
+
+    public get phase(): EnginePhase {
+        return this.currentPhase;
+    }
+
+    private setPhase(phase: EnginePhase) {
+        if (this.currentPhase === phase) return;
+        this.currentPhase = phase;
+        this.emit('phaseChange', phase);
     }
 
     constructor(scene: Phaser.Scene, x: number, y: number, width: number, height: number) {
@@ -113,6 +136,7 @@ export class PlayField extends ObjectBase {
         // Clear inactive tetrominos.
         this.inactiveTetrominos = [];
         this.inactiveBlocksCache = [];
+        this.setPhase(EnginePhase.COMPLETION);
     }
 
     private invalidateInactiveBlocksCache() {
@@ -124,6 +148,7 @@ export class PlayField extends ObjectBase {
      * @param {TetrominoType} type - Tetromino type.
      */
     spawnTetromino(type?: TetrominoType): void {
+        this.setPhase(EnginePhase.GENERATION);
         // Get tetrominoType from param or generate random type from queue.
         let tetrominoType = type;
         if (!tetrominoType) this.emit('generateRandomType', (genType: TetrominoType) => tetrominoType = genType);
@@ -133,6 +158,7 @@ export class PlayField extends ObjectBase {
         if (tetromino.isSpawnSuccess) { // If spawn is success.
             // Set active tetromino with new tetromino.
             this.activeTetromino = tetromino;
+            this.setPhase(EnginePhase.FALLING);
             // Add tetromino ui to play field container.
             this.container.add(this.activeTetromino.container);
             // Check is lockable
@@ -496,12 +522,15 @@ export class PlayField extends ObjectBase {
             return;
         }
 
+        this.setPhase(EnginePhase.PATTERN);
+
         // clear line 
         const clearedRows = this.getClearedRows(lockedTetromino);
         const clearedLineCount = clearedRows.length;
 
         // Proceed function
         const proceed = () => {
+            this.setPhase(EnginePhase.COMPLETION);
              // Emit lock event.
             this.emit('lock',
                 clearedLineCount,
@@ -520,14 +549,19 @@ export class PlayField extends ObjectBase {
 
         if (clearedLineCount > 0) {
             this.pendingClearedRows = clearedRows;
+            this.setPhase(EnginePhase.ITERATE);
+            this.setPhase(EnginePhase.ANIMATE);
             this.playClearAnimation(clearedRows, () => {
                 if (this.pendingClearedRows) {
+                    this.setPhase(EnginePhase.ELIMINATE);
                     this.clearRows(this.pendingClearedRows);
                     this.pendingClearedRows = null;
                 }
                 proceed();
             });
         } else {
+            this.setPhase(EnginePhase.ITERATE);
+            this.setPhase(EnginePhase.ELIMINATE);
             proceed();
         }
     }
@@ -577,6 +611,7 @@ export class PlayField extends ObjectBase {
      */
     startLockTimer() {
         if (this.activeTetromino) {
+            this.setPhase(EnginePhase.LOCK);
             // Lock tetromino after lock animation finished.
             this.activeTetromino.playLockAnimation(() => this.lock());
         }
@@ -612,8 +647,8 @@ export class PlayField extends ObjectBase {
                 // Set dropped rotate type.
                 if (setDroppedRotate) this.droppedRotateType = this.activeTetromino.rotateType;
                 
-                // Restart lock timer only if manipulation count < 15 (Extended Placement).
-                if (this.activeTetromino.manipulationCount < 15) {
+                // Restart lock timer while manipulation count is within the 15 reset limit (Extended Placement).
+                if (this.activeTetromino.manipulationCount <= 15) {
                     this.stopLockTimer();
                     this.startLockTimer();
                 }

--- a/test/unit/guideline.test.ts
+++ b/test/unit/guideline.test.ts
@@ -222,11 +222,11 @@ describe('2009 Tetris Guideline Compliance', () => {
 
              let score2 = engine.getScore() - score1;
 
-             // Level 2 (triggered by first tetris)
-             // Base 800 * B2B 1.5 * Level 2 = 2400
-             // Combo 1 (50*1*2) = 100
-             // Total 2500
-             expect(score2).toBe(2500);
+             // First tetris gives 4 lines, so second tetris is still scored at level 1.
+             // Base 800 * B2B 1.5 * Level 1 = 1200
+             // Combo 1 (50*1*1) = 50
+             // Total 1250
+             expect(score2).toBe(1250);
         });
 
         test('T-Spin Double', () => {

--- a/test/unit/logic/scoreSystem.test.ts
+++ b/test/unit/logic/scoreSystem.test.ts
@@ -50,8 +50,9 @@ describe('ScoreSystem', () => {
             { pointSide: 0, flatSide: 0 }
         );
 
-        // 800 * 1.5 = 1200 * Level 2 + Combo 100 = 2500
-        expect(result.scoreAdded).toBe(2500);
+        // First tetris keeps level 1 (4 lines).
+        // 2nd tetris: 800 * 1.5 * level1 + combo(50*1*1) = 1250
+        expect(result.scoreAdded).toBe(1250);
         expect(result.isBackToBack).toBe(true);
         expect(result.actionName).toContain('Back to Back');
     });
@@ -63,7 +64,10 @@ describe('ScoreSystem', () => {
             { pointSide: 0, flatSide: 0 }
         );
 
-        // Tetris gives 8 lines count. Level 1 requires 5. Should level up.
-        expect(scoreSystem.getLevel()).toBeGreaterThan(1);
+        // Single tetris clears 4 lines, so level should stay at 1 (need 5 lines).
+        expect(scoreSystem.getLevel()).toBe(1);
+
+        scoreSystem.onLock(1, TetrominoType.I, RotateType.UP, RotateType.UP, 'drop', 0, { softDrop: 0, hardDrop: 0, autoDrop: 0 }, { pointSide: 0, flatSide: 0 });
+        expect(scoreSystem.getLevel()).toBe(2);
     });
 });

--- a/test/unit/logic/scoreSystem_garbage.test.ts
+++ b/test/unit/logic/scoreSystem_garbage.test.ts
@@ -270,9 +270,14 @@ describe('ScoreSystem - Auto Drop Delay', () => {
     test('drop delay decreases as level increases', () => {
         const delayL1 = scoreSystem.getAutoDropDelay();
 
-        // Level up by clearing a Tetris
+        // Reach level 2 by clearing total 5 lines.
         scoreSystem.onLock(
             4, TetrominoType.I, RotateType.UP, RotateType.UP, 'drop', 0,
+            { softDrop: 0, hardDrop: 0, autoDrop: 0 },
+            { pointSide: 0, flatSide: 0 }
+        );
+        scoreSystem.onLock(
+            1, TetrominoType.I, RotateType.UP, RotateType.UP, 'drop', 0,
             { softDrop: 0, hardDrop: 0, autoDrop: 0 },
             { pointSide: 0, flatSide: 0 }
         );

--- a/test/unit/playField_delay.test.ts
+++ b/test/unit/playField_delay.test.ts
@@ -1,4 +1,4 @@
-import { PlayField } from '../../src/tetris/objects/playField';
+import { PlayField, EnginePhase } from '../../src/tetris/objects/playField';
 import { Tetromino } from '../../src/tetris/objects/tetromino';
 import { TetrominoType, CONST } from '../../src/tetris/const/const';
 import * as Phaser from 'phaser';
@@ -19,6 +19,8 @@ describe('PlayField Delay', () => {
         const playClearAnimationSpy = jest.spyOn(playField, 'playClearAnimation');
         const clearRowsSpy = jest.spyOn(playField, 'clearRows');
         const emitSpy = jest.spyOn(playField, 'emit');
+        const phases: EnginePhase[] = [];
+        playField.on('phaseChange', (phase: EnginePhase) => phases.push(phase));
 
         // Mock getClearedRows to return a row
         jest.spyOn(playField, 'getClearedRows').mockReturnValue([19]);
@@ -34,12 +36,12 @@ describe('PlayField Delay', () => {
             dropCounter: { softDrop: 0, hardDrop: 0, autoDrop: 0 },
             getTSpinCornerOccupiedCount: () => ({ pointSide: 0, flatSide: 0 }),
             isLockable: () => true,
-            animateBlocksInRows: jest.fn(), // Add this
-            clearLine: jest.fn().mockReturnValue(false), // Add this
+            animateBlocksInRows: jest.fn(),
+            clearLine: jest.fn().mockReturnValue(false),
         } as unknown as Tetromino;
 
         // Inject activeTetromino so lock() works
-        (playField as any).droppedRotateType = '0'; // Fix undefined
+        (playField as any).droppedRotateType = '0';
         (playField as any).activeTetromino = lockedTetromino;
         (playField as any).startLockTimer = jest.fn();
         (playField as any).stopLockTimer = jest.fn();
@@ -64,6 +66,13 @@ describe('PlayField Delay', () => {
 
         // Verify lock emitted
         expect(emitSpy).toHaveBeenCalledWith('lock', 1, expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
+        expect(phases).toEqual([
+            EnginePhase.PATTERN,
+            EnginePhase.ITERATE,
+            EnginePhase.ANIMATE,
+            EnginePhase.ELIMINATE,
+            EnginePhase.COMPLETION,
+        ]);
     });
 
     test('should NOT delay if no lines cleared', () => {
@@ -72,6 +81,8 @@ describe('PlayField Delay', () => {
          const playClearAnimationSpy = jest.spyOn(playField, 'playClearAnimation');
          const clearRowsSpy = jest.spyOn(playField, 'clearRows');
          const emitSpy = jest.spyOn(playField, 'emit');
+         const phases: EnginePhase[] = [];
+         playField.on('phaseChange', (phase: EnginePhase) => phases.push(phase));
 
          jest.spyOn(playField, 'getClearedRows').mockReturnValue([]);
 
@@ -99,5 +110,33 @@ describe('PlayField Delay', () => {
         expect(clearRowsSpy).not.toHaveBeenCalled();
         // Lock emitted immediately
         expect(emitSpy).toHaveBeenCalledWith('lock', 0, expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
+        expect(phases).toEqual([
+            EnginePhase.PATTERN,
+            EnginePhase.ITERATE,
+            EnginePhase.ELIMINATE,
+            EnginePhase.COMPLETION,
+        ]);
+    });
+
+    test('setLockTimer allows reset at manipulationCount 15 but blocks after 16', () => {
+        const stopSpy = jest.spyOn(playField, 'stopLockTimer').mockImplementation(() => {});
+        const startSpy = jest.spyOn(playField, 'startLockTimer').mockImplementation(() => {});
+
+        const active = {
+            isLockable: jest.fn().mockReturnValue(true),
+            manipulationCount: 15,
+            rotateType: '0'
+        };
+
+        (playField as any).activeTetromino = active;
+
+        playField.setLockTimer(true, true);
+        expect(stopSpy).toHaveBeenCalledTimes(1);
+        expect(startSpy).toHaveBeenCalledTimes(1);
+
+        active.manipulationCount = 16;
+        playField.setLockTimer(true, true);
+        expect(stopSpy).toHaveBeenCalledTimes(1);
+        expect(startSpy).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
### Motivation
- Fix correctness gaps surfaced by the guideline audit: Extended Placement off-by-one in lock-reset behavior, and level progression using weighted action counts rather than actual cleared lines. 
- Improve runtime observability and regression protection by making the engine flow (Appendix A) explicit in code so phase transitions can be asserted and audited. 

### Description
- Added an `EnginePhase` enum and per-playfield phase state with `phaseChange` events, and injected phase transitions at spawn, falling, lock start, and through the lock/clear sequence (`Pattern → Iterate → Animate → Eliminate → Completion`).
- Corrected Extended Placement boundary by changing lock-reset condition to allow resets while `manipulationCount <= 15` and block resets at 16. 
- Switched level progression to accumulate actual cleared lines by using `clearedLineCount` in `ScoreSystem` (`addLineCount(clearedLineCount)`), replacing the previous weighted-action accumulation. 
- Updated and added unit tests to reflect the new behavior: adjusted B2B score/level expectations, added phase-order assertions in the playfield clear-delay test, added lock-reset boundary test (15 vs 16), and updated auto-drop delay leveling test to simulate reaching level 2 by clearing 5 lines. 

### Testing
- Ran targeted tests with `npm test -- --runInBand test/unit/logic/scoreSystem.test.ts test/unit/guideline.test.ts test/unit/playField_delay.test.ts` and observed all targeted tests passing. 
- Ran the full suite with `npm test -- --runInBand` and verified success: 25 test suites passed and 231 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69945557aad08320a0f803ba681f8fca)