### PR TITLE
Fix n-multi garbage targeting when opponents are game over

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -321,7 +321,11 @@ io.on('connection', (socket) => {
         if (!data || !data.roomId || !data.targetId || !data.count) return;
         const room = nMultiRooms[data.roomId];
         if (!room || !room.players[socket.id]) return;
-        if (!room.players[data.targetId]) return;
+        const sender = room.players[socket.id];
+        const target = room.players[data.targetId];
+        if (!target) return;
+        if (data.targetId === socket.id) return;
+        if (sender.isAlive === false || target.isAlive === false) return;
         io.to(data.targetId).emit('nmulti_receive_garbage', {
             count: data.count,
             fromId: socket.id
@@ -420,7 +424,7 @@ io.on('connection', (socket) => {
         if (!room || !room.players[socket.id]) return;
 
         socket.emit('nmulti_snapshot', {
-            players: getPlayersMap(room),
+            players: getPlayersMap(room, socket.id),
             isDelta: false
         });
     });
@@ -510,9 +514,10 @@ function getNMultiRoomList() {
     }));
 }
 
-function getPlayersMap(room) {
+function getPlayersMap(room, excludeId = null) {
     const map = {};
     for (const [sid, p] of Object.entries(room.players)) {
+        if (excludeId && sid === excludeId) continue;
         map[sid] = {
             name: p.name,
             score: p.score,

--- a/src/tetris/scenes/nMultiPlayScene.ts
+++ b/src/tetris/scenes/nMultiPlayScene.ts
@@ -136,7 +136,12 @@ export class NMultiPlayScene extends BaseScene {
 
             // Merge delta or replace full state
             if (!isDelta) {
-                this.snapshotPlayers = data.players;
+                const nextSnapshotPlayers: Record<string, any> = {};
+                for (const [id, p] of Object.entries(data.players) as [string, any][]) {
+                    if (id === this.playerId) continue; // Ignore self
+                    nextSnapshotPlayers[id] = p;
+                }
+                this.snapshotPlayers = nextSnapshotPlayers;
             } else {
                 for (const [id, p] of Object.entries(data.players) as [string, any][]) {
                     if (id === this.playerId) continue; // Ignore self
@@ -276,6 +281,7 @@ export class NMultiPlayScene extends BaseScene {
 
         // Add opponents from snapshot
         for (const [id, p] of Object.entries(this.snapshotPlayers) as [string, any][]) {
+            if (id === this.playerId) continue;
             entries.push({ playerId: id, score: p.score || 0 });
         }
 
@@ -401,14 +407,8 @@ export class NMultiPlayScene extends BaseScene {
         // Send garbage to a random alive opponent
         this.engine.setAttackHandler((count) => {
             if (!this.socket) return;
-            const aliveOpponents: string[] = [];
-            for (const [id, p] of Object.entries(this.snapshotPlayers) as [string, any][]) {
-                if (p.isAlive !== false) {
-                    aliveOpponents.push(id);
-                }
-            }
-            if (aliveOpponents.length === 0) return;
-            const targetId = aliveOpponents[Math.floor(Math.random() * aliveOpponents.length)];
+            const targetId = this.pickRandomAliveOpponentId();
+            if (!targetId) return;
             this.socket.emit('nmulti_send_garbage', {
                 roomId: this.roomId,
                 targetId,
@@ -478,5 +478,16 @@ export class NMultiPlayScene extends BaseScene {
         if (this.engine) {
             this.engine.onInput(direction, state);
         }
+    }
+
+    private pickRandomAliveOpponentId(): string | null {
+        const aliveOpponents: string[] = [];
+        for (const [id, p] of Object.entries(this.snapshotPlayers) as [string, any][]) {
+            if (id !== this.playerId && p.isAlive !== false) {
+                aliveOpponents.push(id);
+            }
+        }
+        if (aliveOpponents.length === 0) return null;
+        return aliveOpponents[Math.floor(Math.random() * aliveOpponents.length)];
     }
 }

--- a/test/unit/scenes/nMultiPlayScene.garbageTarget.test.ts
+++ b/test/unit/scenes/nMultiPlayScene.garbageTarget.test.ts
@@ -1,0 +1,53 @@
+import { NMultiPlayScene } from '../../../src/tetris/scenes/nMultiPlayScene';
+
+describe('NMultiPlayScene garbage target selection', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('selects only alive opponents and excludes self', () => {
+        const scene = new NMultiPlayScene() as any;
+        scene.playerId = 'me';
+        scene.snapshotPlayers = {
+            me: { isAlive: true },
+            aliveA: { isAlive: true },
+            deadB: { isAlive: false },
+            aliveC: { isAlive: true }
+        };
+
+        jest.spyOn(Math, 'random').mockReturnValue(0.75);
+        const targetId = scene.pickRandomAliveOpponentId();
+
+        expect(['aliveA', 'aliveC']).toContain(targetId);
+        expect(targetId).not.toBe('me');
+        expect(targetId).not.toBe('deadB');
+    });
+
+    test('returns different opponent when random bucket changes', () => {
+        const scene = new NMultiPlayScene() as any;
+        scene.playerId = 'me';
+        scene.snapshotPlayers = {
+            opp1: { isAlive: true },
+            opp2: { isAlive: true }
+        };
+
+        jest.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0.99);
+        const first = scene.pickRandomAliveOpponentId();
+        const second = scene.pickRandomAliveOpponentId();
+
+        expect(first).toBe('opp1');
+        expect(second).toBe('opp2');
+    });
+
+    test('returns null when no alive opponent exists', () => {
+        const scene = new NMultiPlayScene() as any;
+        scene.playerId = 'me';
+        scene.snapshotPlayers = {
+            me: { isAlive: true },
+            dead1: { isAlive: false }
+        };
+
+        const targetId = scene.pickRandomAliveOpponentId();
+        expect(targetId).toBeNull();
+    });
+});

--- a/test/unit/server/nMultiServer.test.ts
+++ b/test/unit/server/nMultiServer.test.ts
@@ -37,6 +37,16 @@ describe('N-Multi Server Logic', () => {
         return map;
     }
 
+    function canSendGarbage(room: any, senderId: string, targetId: string, count: number) {
+        if (!room || !senderId || !targetId || !count) return false;
+        const sender = room.players[senderId];
+        const target = room.players[targetId];
+        if (!sender || !target) return false;
+        if (senderId === targetId) return false;
+        if (sender.isAlive === false || target.isAlive === false) return false;
+        return true;
+    }
+
     function buildSnapshot(room: any, excludeId: string) {
         const playerIds = Object.keys(room.players);
         const snapshot: Record<string, any> = {};
@@ -447,6 +457,38 @@ describe('N-Multi Server Logic', () => {
             // Missing fields
             const noCount = { roomId, targetId: 'target', count: 0 };
             expect(!noCount.count).toBe(true); // Server checks !data.count
+        });
+
+        test('rejects sending garbage to self', () => {
+            const room = {
+                players: {
+                    sender: { isAlive: true }
+                }
+            };
+
+            expect(canSendGarbage(room, 'sender', 'sender', 2)).toBe(false);
+        });
+
+        test('rejects sending garbage to dead target', () => {
+            const room = {
+                players: {
+                    sender: { isAlive: true },
+                    target: { isAlive: false }
+                }
+            };
+
+            expect(canSendGarbage(room, 'sender', 'target', 2)).toBe(false);
+        });
+
+        test('rejects dead sender from sending garbage', () => {
+            const room = {
+                players: {
+                    sender: { isAlive: false },
+                    target: { isAlive: true }
+                }
+            };
+
+            expect(canSendGarbage(room, 'sender', 'target', 2)).toBe(false);
         });
     });
 


### PR DESCRIPTION
## Summary
- prevent n-multi garbage from targeting self or dead players on server side
- exclude self from full snapshot payload and reinforce self filtering in NMultiPlayScene
- extract random target picker and add scene-level tests for random alive-opponent selection
- add server-side validation tests for self/dead-target garbage cases

## Testing
- npm test -- --runInBand --runTestsByPath test/unit/server/nMultiServer.test.ts
- npm test -- --runInBand --runTestsByPath test/unit/scenes/nMultiPlayScene.garbageTarget.test.ts
