### PR TITLE
feat: add per-piece spin action labels and hooks

### DIFF
--- a/src/shared/core/authoritativeMatch.ts
+++ b/src/shared/core/authoritativeMatch.ts
@@ -274,21 +274,23 @@ function clearLines(player: PlayerState): number {
 
 function lockPiece(player: PlayerState): number {
     if (!player.active || !player.isAlive) return 0;
-    const blocks = cloneActiveBlocks(player.active);
+    const locked = player.active;
+    const isImmobileAtLock = isImmobile(player, locked);
+    const blocks = cloneActiveBlocks(locked);
     for (const [x, y] of blocks) {
         if (y < 0) {
             player.isAlive = false;
             player.active = null;
             return 0;
         }
-        player.board[y][x] = player.active.type;
+        player.board[y][x] = locked.type;
     }
 
-    const locked = player.active;
     // Match client behavior: T-Spin corner occupancy is evaluated
     // against the pre-line-clear locked board state.
     const tSpinCornerOccupiedCount = getTSpinCornerOccupiedCount(player, locked);
     const cleared = clearLines(player);
+    const isPerfectClear = player.board.every((row) => row.every((cell) => cell === '0'));
     const scoreResult = player.scoreSystem.onLock(
         cleared,
         locked.type,
@@ -298,6 +300,10 @@ function lockPiece(player: PlayerState): number {
         locked.lastKickDataIndex,
         locked.dropCounter,
         tSpinCornerOccupiedCount,
+        {
+            isImmobile: isImmobileAtLock,
+            isPerfectClear,
+        },
     );
     updateLastLockFeedback(player, scoreResult);
 
@@ -306,10 +312,7 @@ function lockPiece(player: PlayerState): number {
     player.level = stats.level;
     player.lines = stats.lines;
 
-    let garbage = scoreResult.garbage;
-    if (player.board.every((row) => row.every((cell) => cell === '0'))) {
-        garbage += 10;
-    }
+    const garbage = scoreResult.garbage;
 
     player.active = null;
     spawn(player);
@@ -351,6 +354,12 @@ function moveDown(player: PlayerState, dropType: 'softDrop' | 'hardDrop' | 'auto
 
 function isLockable(player: PlayerState, active: ActivePiece): boolean {
     return !canPlace(player, active, active.col, active.row + 1, active.rotate);
+}
+
+function isImmobile(player: PlayerState, active: ActivePiece): boolean {
+    return !canPlace(player, active, active.col - 1, active.row, active.rotate)
+        && !canPlace(player, active, active.col + 1, active.row, active.rotate)
+        && !canPlace(player, active, active.col, active.row + 1, active.rotate);
 }
 
 function handleSuccessfulManipulation(player: PlayerState): void {

--- a/src/tetris/const/const.ts
+++ b/src/tetris/const/const.ts
@@ -39,11 +39,45 @@ export interface ColRow extends Array<number> {
     [key: number]: number;
 }
 
+const NON_T_SPIN_ACTION_BONUS_DEFAULTS = {
+    'I-Spin': 0,
+    'I-Spin Single': 0,
+    'I-Spin Double': 0,
+    'I-Spin Triple': 0,
+    'I-Spin Tetris': 0,
+    'J-Spin': 0,
+    'J-Spin Single': 0,
+    'J-Spin Double': 0,
+    'J-Spin Triple': 0,
+    'J-Spin Tetris': 0,
+    'L-Spin': 0,
+    'L-Spin Single': 0,
+    'L-Spin Double': 0,
+    'L-Spin Triple': 0,
+    'L-Spin Tetris': 0,
+    'O-Spin': 0,
+    'O-Spin Single': 0,
+    'O-Spin Double': 0,
+    'O-Spin Triple': 0,
+    'O-Spin Tetris': 0,
+    'S-Spin': 0,
+    'S-Spin Single': 0,
+    'S-Spin Double': 0,
+    'S-Spin Triple': 0,
+    'S-Spin Tetris': 0,
+    'Z-Spin': 0,
+    'Z-Spin Single': 0,
+    'Z-Spin Double': 0,
+    'Z-Spin Triple': 0,
+    'Z-Spin Tetris': 0,
+};
+
 export const CONST = {
     SCORE: {
         'Single': 100,
         'T-Spin Mini': 100,
         'T-Spin Mini Single': 200,
+        'T-Spin Mini Double': 400,
         'Double': 300,
         'T-Spin': 400,
         'Triple': 500,
@@ -56,6 +90,7 @@ export const CONST = {
         'Single': 1,
         'T-Spin Mini': 1,
         'T-Spin Mini Single': 2,
+        'T-Spin Mini Double': 4,
         'Double': 3,
         'T-Spin': 4,
         'Triple': 5,
@@ -63,6 +98,16 @@ export const CONST = {
         'T-Spin Single': 8,
         'T-Spin Double': 12,
         'T-Spin Triple': 16
+    },
+    ACTION_SCORE_BONUS: {
+        // Reserved for optional mode-specific bonuses.
+        // Keep zero by default so spin labels can be introduced without balance changes.
+        ...NON_T_SPIN_ACTION_BONUS_DEFAULTS
+    },
+    ACTION_GARBAGE_BONUS: {
+        // Reserved for optional mode-specific garbage bonuses.
+        // Keep zero by default so spin labels can be introduced without attack changes.
+        ...NON_T_SPIN_ACTION_BONUS_DEFAULTS
     },
     SCREEN : {
         BLOCK_IMAGE_SIZE: 36,

--- a/src/tetris/engine.ts
+++ b/src/tetris/engine.ts
@@ -119,6 +119,7 @@ export class Engine {
      * @param {number} kickDataIndex - Kick data index. (how many kick occurred.)
      * @param {{ softDrop: number, hardDrop: number, autoDrop: number }} dropCounter - Drop count data.
      * @param {{ pointSide: number, flatSide: number }} tSpinCornerOccupiedCount - T tetromino corner occupied count.
+     * @param {{ isImmobile?: boolean }} lockContext - Optional lock context for extended action labels.
      */
     onLock(
         clearedLineCount: number,
@@ -128,8 +129,10 @@ export class Engine {
         movement: string,
         kickDataIndex: number,
         dropCounter: { softDrop: number, hardDrop: number, autoDrop: number },
-        tSpinCornerOccupiedCount: { pointSide: number, flatSide: number }
+        tSpinCornerOccupiedCount: { pointSide: number, flatSide: number },
+        lockContext?: { isImmobile?: boolean }
     ) {
+        const isPerfectClear = this.playField.getInactiveBlocks().length === 0;
         const result = this.scoreSystem.onLock(
             clearedLineCount,
             tetrominoType,
@@ -138,7 +141,11 @@ export class Engine {
             movement,
             kickDataIndex,
             dropCounter,
-            tSpinCornerOccupiedCount
+            tSpinCornerOccupiedCount,
+            {
+                isImmobile: lockContext?.isImmobile === true,
+                isPerfectClear,
+            }
         );
 
         if (this.isDebugLogging && result.scoreAdded > 0 && result.actionName) {
@@ -165,12 +172,7 @@ export class Engine {
         this.playField.autoDropDelay = this.scoreSystem.getAutoDropDelay();
 
         // Calculate Garbage (Multiplayer)
-        let garbage = result.garbage;
-
-        // Perfect Clear
-        if (this.playField.getInactiveBlocks().length === 0) {
-            garbage += 10;
-        }
+        const garbage = result.garbage;
 
         // Send Garbage
         if (garbage > 0 && this.onAttack) {

--- a/src/tetris/logic/gameRules.ts
+++ b/src/tetris/logic/gameRules.ts
@@ -27,11 +27,28 @@ export class GameRules {
     }
 
     /**
+     * Get additional score bonus for an action.
+     * This is intentionally separate from base score so optional rules
+     * can be enabled by editing constants without changing scoring flow.
+     */
+    static getActionScoreBonus(actionName: string): number {
+        return CONST.ACTION_SCORE_BONUS[actionName] || 0;
+    }
+
+    /**
      * Get the number of lines to send/count for an action.
      * @param actionName The name of the action.
      * @returns The line count.
      */
     static getLineCount(actionName: string): number {
         return CONST.LINE_COUNT[actionName] || 0;
+    }
+
+    /**
+     * Get additional garbage bonus for an action.
+     * Kept decoupled from base attack math for optional future tuning.
+     */
+    static getActionGarbageBonus(actionName: string): number {
+        return CONST.ACTION_GARBAGE_BONUS[actionName] || 0;
     }
 }

--- a/src/tetris/logic/scoreSystem.ts
+++ b/src/tetris/logic/scoreSystem.ts
@@ -31,6 +31,12 @@ export interface GarbageAttackInput {
     isBackToBackBonus: boolean;
     comboCount: number;
     isPerfectClear?: boolean;
+    actionName?: string | null;
+}
+
+export interface LockContext {
+    isImmobile?: boolean;
+    isPerfectClear?: boolean;
 }
 
 export class ScoreSystem {
@@ -123,6 +129,10 @@ export class ScoreSystem {
             garbage += 10;
         }
 
+        if (input.actionName) {
+            garbage += GameRules.getActionGarbageBonus(input.actionName);
+        }
+
         return garbage;
     }
 
@@ -176,18 +186,21 @@ export class ScoreSystem {
         movement: string,
         kickDataIndex: number,
         dropCounter: { softDrop: number, hardDrop: number, autoDrop: number },
-        tSpinCornerOccupiedCount: { pointSide: number, flatSide: number }
+        tSpinCornerOccupiedCount: { pointSide: number, flatSide: number },
+        lockContext?: LockContext
     ): LockResult {
         this.totalPiecesLocked++;
         this.totalLinesCleared += clearedLineCount;
 
         const { pointSide, flatSide } = tSpinCornerOccupiedCount;
+        const isRotateLock = droppedRotateType != lockedRotateType && movement == 'rotate';
+        const isImmobile = lockContext?.isImmobile === true;
+        const isPerfectClear = lockContext?.isPerfectClear === true;
 
         // Is T-Spin
         const isTSpin =
             tetrominoType == TetrominoType.T &&
-            droppedRotateType != lockedRotateType &&
-            movement == 'rotate' &&
+            isRotateLock &&
             pointSide + flatSide > 2;
 
         if (isTSpin) this.tSpinCount++;
@@ -199,6 +212,14 @@ export class ScoreSystem {
             pointSide < 2 &&
             kickDataIndex < 3;
 
+        // Optional non-T spin labeling. Kept score/garbage-neutral by default.
+        const isNonTSpin =
+            !isTSpin &&
+            tetrominoType !== TetrominoType.T &&
+            tetrominoType !== TetrominoType.GARBAGE &&
+            isRotateLock &&
+            isImmobile;
+
         let isBackToBackBonus = false;
         if (this.isBackToBackChain) {
             this.isBackToBackChain = Boolean(isTSpin || clearedLineCount == 4 || !clearedLineCount);
@@ -207,21 +228,36 @@ export class ScoreSystem {
             this.isBackToBackChain = Boolean((isTSpin && clearedLineCount) || clearedLineCount == 4);
         }
 
+        const clearedLineAction = clearedLineCount
+            ? ['Single', 'Double', 'Triple', 'Tetris'][clearedLineCount - 1]
+            : null;
+
         const actionNameArray: string[] = [];
-        if (isTSpin) actionNameArray.push('T-Spin');
-        if (isTSpinMini) actionNameArray.push('Mini');
-        if (clearedLineCount) actionNameArray.push(['Single', 'Double', 'Triple', 'Tetris'][clearedLineCount - 1]);
+        if (isTSpin) {
+            actionNameArray.push('T-Spin');
+            if (isTSpinMini) actionNameArray.push('Mini');
+        } else if (isNonTSpin) {
+            actionNameArray.push(`${tetrominoType}-Spin`);
+        }
+        if (clearedLineAction) actionNameArray.push(clearedLineAction);
 
         let actionName: string | null = null;
-        let scoreBase = 0;
+        let scoreBaseAction: string | null = null;
         if (actionNameArray.length) {
             actionName = actionNameArray.join(' ');
-            scoreBase = GameRules.getBaseScore(actionName);
+            if (isTSpin) {
+                scoreBaseAction = actionName;
+            } else if (clearedLineAction) {
+                // Non-T spin labels keep base line-clear score by default.
+                scoreBaseAction = clearedLineAction;
+            }
         }
 
+        const scoreBase = scoreBaseAction ? GameRules.getBaseScore(scoreBaseAction) : 0;
         let scoreAdded = 0;
-        if (scoreBase) {
-            const score = scoreBase * (isBackToBackBonus ? 1.5 : 1) * this.level;
+        const actionScoreBase = scoreBase + (actionName ? GameRules.getActionScoreBonus(actionName) : 0);
+        if (actionScoreBase) {
+            const score = actionScoreBase * (isBackToBackBonus ? 1.5 : 1) * this.level;
             scoreAdded += score;
         }
 
@@ -255,6 +291,8 @@ export class ScoreSystem {
             isTSpinMini,
             isBackToBackBonus,
             comboCount: this.comboCount,
+            isPerfectClear,
+            actionName,
         });
 
         // Return result

--- a/src/tetris/objects/playField.ts
+++ b/src/tetris/objects/playField.ts
@@ -539,6 +539,7 @@ export class PlayField extends ObjectBase {
         // If lockable active tetromino is not exist, stop function.
         if (!this.activeTetromino) return;
         if (!this.activeTetromino.isLockable()) return;
+        const isImmobileAtLock = this.activeTetromino.isImmobile();
         // Stop auto drop timer.
         this.stopAutoDropTimer();
         // Inactive tetromino.
@@ -575,7 +576,8 @@ export class PlayField extends ObjectBase {
                 lockedTetromino.lastMovement,
                 lockedTetromino.lastKickDataIndex,
                 lockedTetromino.dropCounter,
-                lockedTetromino.getTSpinCornerOccupiedCount()
+                lockedTetromino.getTSpinCornerOccupiedCount(),
+                { isImmobile: isImmobileAtLock }
             );
 
             // ARE

--- a/src/tetris/objects/tetromino.ts
+++ b/src/tetris/objects/tetromino.ts
@@ -271,6 +271,16 @@ export class Tetromino extends ObjectBase {
     }
 
     /**
+     * Check whether the piece is immobile in its current state.
+     * Used as an optional non-T spin labeling signal.
+     */
+    isImmobile(): boolean {
+        return !this.isValidPosition(this.rotateType, this.col - 1, this.row)
+            && !this.isValidPosition(this.rotateType, this.col + 1, this.row)
+            && !this.isValidPosition(this.rotateType, this.col, this.row + 1);
+    }
+
+    /**
      * Clear line and pull down upper blocks.
      * @param {number} row - Row to clear.
      */

--- a/test/unit/logic/scoreSystem.test.ts
+++ b/test/unit/logic/scoreSystem.test.ts
@@ -39,6 +39,52 @@ describe('ScoreSystem', () => {
         expect(result.actionName).toBe('Tetris');
     });
 
+    test('T-Spin Mini Double uses configured base score', () => {
+        const result = scoreSystem.onLock(
+            2, TetrominoType.T, RotateType.UP, RotateType.RIGHT, 'rotate', 0,
+            { softDrop: 0, hardDrop: 0, autoDrop: 0 },
+            { pointSide: 1, flatSide: 2 }
+        );
+
+        expect(result.actionName).toBe('T-Spin Mini Double');
+        expect(result.scoreAdded).toBe(400);
+    });
+
+    test('J-Spin Single keeps base line-clear scoring and adds only label', () => {
+        const result = scoreSystem.onLock(
+            1, TetrominoType.J, RotateType.UP, RotateType.RIGHT, 'rotate', 0,
+            { softDrop: 0, hardDrop: 0, autoDrop: 0 },
+            { pointSide: 0, flatSide: 0 },
+            { isImmobile: true }
+        );
+
+        expect(result.actionName).toBe('J-Spin Single');
+        expect(result.scoreAdded).toBe(100);
+    });
+
+    test('labels non-T spins by tetromino type', () => {
+        const nonTTypes = [
+            TetrominoType.I,
+            TetrominoType.J,
+            TetrominoType.L,
+            TetrominoType.O,
+            TetrominoType.S,
+            TetrominoType.Z,
+        ];
+
+        for (const type of nonTTypes) {
+            const isolatedScoreSystem = new ScoreSystem();
+            const result = isolatedScoreSystem.onLock(
+                1, type, RotateType.UP, RotateType.RIGHT, 'rotate', 0,
+                { softDrop: 0, hardDrop: 0, autoDrop: 0 },
+                { pointSide: 0, flatSide: 0 },
+                { isImmobile: true }
+            );
+            expect(result.actionName).toBe(`${type}-Spin Single`);
+            expect(result.scoreAdded).toBe(100);
+        }
+    });
+
     test('Back to Back Tetris', () => {
         // First Tetris
         scoreSystem.onLock(4, TetrominoType.I, RotateType.UP, RotateType.UP, 'drop', 0, { softDrop: 0, hardDrop: 0, autoDrop: 0 }, { pointSide: 0, flatSide: 0 });

--- a/test/unit/logic/scoreSystem_garbage.test.ts
+++ b/test/unit/logic/scoreSystem_garbage.test.ts
@@ -31,6 +31,14 @@ describe('ScoreSystem - Garbage Calculation', () => {
         expect(result.garbage).toBe(0);
     });
 
+    test('Perfect Clear adds 10 garbage through lock context', () => {
+        const result = scoreSystem.onLock(
+            1, TetrominoType.I, RotateType.UP, RotateType.UP, 'drop', 0,
+            defaultDrop, noCorner, { isPerfectClear: true }
+        );
+        expect(result.garbage).toBe(10);
+    });
+
     test('Double clear produces 1 garbage', () => {
         const result = scoreSystem.onLock(
             2, TetrominoType.I, RotateType.UP, RotateType.UP, 'drop', 0,
@@ -77,6 +85,15 @@ describe('ScoreSystem - Garbage Calculation', () => {
             defaultDrop, { pointSide: 2, flatSide: 1 }
         );
         expect(result.garbage).toBe(6);
+    });
+
+    test('J-Spin Double keeps base line-clear garbage by default', () => {
+        const result = scoreSystem.onLock(
+            2, TetrominoType.J, RotateType.UP, RotateType.RIGHT, 'rotate', 0,
+            defaultDrop, noCorner, { isImmobile: true }
+        );
+        expect(result.actionName).toBe('J-Spin Double');
+        expect(result.garbage).toBe(1);
     });
 
     test('Back-to-Back Tetris adds 1 bonus garbage', () => {

--- a/test/unit/playField_delay.test.ts
+++ b/test/unit/playField_delay.test.ts
@@ -36,6 +36,7 @@ describe('PlayField Delay', () => {
             dropCounter: { softDrop: 0, hardDrop: 0, autoDrop: 0 },
             getTSpinCornerOccupiedCount: () => ({ pointSide: 0, flatSide: 0 }),
             isLockable: () => true,
+            isImmobile: () => false,
             animateBlocksInRows: jest.fn(),
             clearLine: jest.fn().mockReturnValue(false),
         } as unknown as Tetromino;
@@ -56,7 +57,7 @@ describe('PlayField Delay', () => {
         // Verify clearRows NOT called yet
         expect(clearRowsSpy).not.toHaveBeenCalled();
         // Verify lock NOT emitted yet (it is inside the proceed callback which runs after animation)
-        expect(emitSpy).not.toHaveBeenCalledWith('lock', expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
+        expect(emitSpy).not.toHaveBeenCalledWith('lock', expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
 
         // Advance time by LINE_CLEAR_DELAY_MS
         jest.advanceTimersByTime(CONST.PLAY_FIELD.LINE_CLEAR_DELAY_MS);
@@ -65,7 +66,7 @@ describe('PlayField Delay', () => {
         expect(clearRowsSpy).toHaveBeenCalledWith([19]);
 
         // Verify lock emitted
-        expect(emitSpy).toHaveBeenCalledWith('lock', 1, expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
+        expect(emitSpy).toHaveBeenCalledWith('lock', 1, expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
         expect(phases).toEqual([
             EnginePhase.PATTERN,
             EnginePhase.ITERATE,
@@ -96,6 +97,7 @@ describe('PlayField Delay', () => {
             dropCounter: { softDrop: 0, hardDrop: 0, autoDrop: 0 },
             getTSpinCornerOccupiedCount: () => ({ pointSide: 0, flatSide: 0 }),
             isLockable: () => true,
+            isImmobile: () => false,
         } as unknown as Tetromino;
 
         (playField as any).droppedRotateType = '0';
@@ -109,7 +111,7 @@ describe('PlayField Delay', () => {
         expect(playClearAnimationSpy).not.toHaveBeenCalled();
         expect(clearRowsSpy).not.toHaveBeenCalled();
         // Lock emitted immediately
-        expect(emitSpy).toHaveBeenCalledWith('lock', 0, expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
+        expect(emitSpy).toHaveBeenCalledWith('lock', 0, expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
         expect(phases).toEqual([
             EnginePhase.PATTERN,
             EnginePhase.ITERATE,


### PR DESCRIPTION
## Summary
- replace generic non-T All-Spin labeling with per-piece spin labels (I/J/L/O/S/Z-Spin)
- keep non-T spin scoring/garbage neutral by default while preserving base line-clear score and attack
- add explicit score/garbage hook tables for each non-T spin action so tuning can be enabled later without flow changes
- unify perfect-clear +10 garbage through ScoreSystem lock context on both client engine and authoritative server
- fill missing T-Spin Mini Double base score and update lock-context plumbing/tests

## Validation
- npm test -- --runTestsByPath test/unit/logic/scoreSystem.test.ts test/unit/logic/scoreSystem_garbage.test.ts test/unit/playField_delay.test.ts
- npm test -- --runTestsByPath test/unit/server/serverIndex.integration.test.ts
- npm run build

## Notes
- npm test full suite still intermittently times out in test/unit/server/serverIndex.integration.test.ts during beforeAll server build/setup; this is pre-existing and reproduced unchanged in this branch.