### PR TITLE
Wait for authoritative snapshot before showing Game Over in multiplayer

### DIFF
--- a/src/tetris/scenes/nMultiPlayScene.ts
+++ b/src/tetris/scenes/nMultiPlayScene.ts
@@ -649,6 +649,10 @@ export class NMultiPlayScene extends BasePlayScene {
         });
 
         this.playField.on('gameOver', () => {
+            if (this.socket) {
+                this.socket.emit('nmulti_game_over', { roomId: this.roomId });
+                return;
+            }
             const score = this.engine ? this.engine.getScore() : 0;
             this.showEndGameMessage('GAME OVER', '#ff0000', score);
         });

--- a/src/tetris/scenes/playScene.ts
+++ b/src/tetris/scenes/playScene.ts
@@ -956,6 +956,9 @@ export class PlayScene extends BasePlayScene {
         this.playField.on('gameOver', () => {
             if (this.mode === 'multi' && this.socket) {
                 this.socket.emit('game_over', { roomId: this.roomId });
+                if (this.useAuthoritativeServer) {
+                    return;
+                }
             }
             const score = this.engine ? this.engine.getScore() : 0;
             this.showEndGameMessage('GAME OVER', '#ff0000', score);


### PR DESCRIPTION
### Motivation
- Prevent a client-side race where the local scene shows the Game Over overlay before the server-authored final snapshot (which may include the last locked tetromino) is applied in multiplayer authoritative modes.

### Description
- In `src/tetris/scenes/playScene.ts` stop immediately displaying the end-game overlay when running in `mode === 'multi'` with `useAuthoritativeServer` enabled, instead emit `game_over` and wait for server-driven `auth_snapshot`/`auth_round_over` to drive the UI.
- In `src/tetris/scenes/nMultiPlayScene.ts` emit `nmulti_game_over` on local `playField` game over and return early so the final `nmulti_auth_snapshot` controls the visual end-game state.

### Testing
- Ran targeted tests `test/unit/scenes/playScene.authoritativeScore.test.ts` and `test/unit/scenes/nMultiPlayScene.payloadGuards.test.ts`, both passed.
- Ran full unit suite via `npm test` (39 test suites, 204 tests) and `npm run build`; all tests passed and build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a398b6d6248320adb100e34e8eb7da)