### PR TITLE
Render opponent buffer (active piece) from authoritative sync in 1v1

### DIFF
--- a/src/tetris/scenes/playScene.ts
+++ b/src/tetris/scenes/playScene.ts
@@ -231,7 +231,14 @@ export class PlayScene extends BasePlayScene {
             return;
         }
 
-        if (opponent.board) {
+        if (opponent.sync) {
+            this.opponentPlayField?.applyAuthoritativeState(
+                opponent.sync.boardCore,
+                opponent.sync.active,
+                opponent.sync.canHold,
+            );
+            this.lastOpponentBoardSnapshot = null;
+        } else if (opponent.board) {
             this.applyOpponentBoardSnapshot(opponent.board);
         }
 

--- a/test/unit/scenes/playScene.authoritativeResync.test.ts
+++ b/test/unit/scenes/playScene.authoritativeResync.test.ts
@@ -35,6 +35,21 @@ function buildSyncSnapshot(board: string, serverAckInputSeq?: number): AuthSnaps
             level: 2,
             lines: 10,
             isAlive: true,
+            sync: {
+                boardCore: board,
+                active: {
+                    type: 'L',
+                    rotate: 'R',
+                    col: 4,
+                    row: -1,
+                },
+                hold: null,
+                canHold: true,
+                queue: ['I', 'T', 'S', 'Z', 'J'],
+                bag: ['L', 'O'],
+                queueRngState: 97531,
+                gravityMsCounter: 15,
+            },
         },
         serverAckInputSeq,
     };
@@ -60,7 +75,7 @@ describe('PlayScene authoritative resync', () => {
         });
         Reflect.set(scene, 'inputManager', { isEnabled: true });
         Reflect.set(scene, 'inGameMenu', { isMenuOpen: false });
-        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded: jest.fn() });
+        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded: jest.fn(), applyAuthoritativeState: jest.fn() });
         Reflect.set(scene, 'playField', {
             serializeEncoded: jest.fn(() => '9'.repeat(200)),
             stop: jest.fn(),
@@ -119,7 +134,7 @@ describe('PlayScene authoritative resync', () => {
         });
         Reflect.set(scene, 'inputManager', { isEnabled: true });
         Reflect.set(scene, 'inGameMenu', { isMenuOpen: false });
-        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded: jest.fn() });
+        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded: jest.fn(), applyAuthoritativeState: jest.fn() });
         Reflect.set(scene, 'playField', {
             serializeEncoded: jest.fn(() => '9'.repeat(200)),
             stop: jest.fn(),
@@ -153,7 +168,7 @@ describe('PlayScene authoritative resync', () => {
         const scene = new PlayScene();
         const handlers: HandlerMap = {};
         const emit = jest.fn();
-        const deserializeEncoded = jest.fn();
+        const applyAuthoritativeState = jest.fn();
 
         Reflect.set(scene, 'mode', 'multi');
         Reflect.set(scene, 'useAuthoritativeServer', true);
@@ -168,7 +183,7 @@ describe('PlayScene authoritative resync', () => {
         });
         Reflect.set(scene, 'inputManager', { isEnabled: true });
         Reflect.set(scene, 'inGameMenu', { isMenuOpen: false });
-        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded });
+        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded: jest.fn(), applyAuthoritativeState });
         Reflect.set(scene, 'playField', {
             serializeEncoded: jest.fn(() => '0'.repeat(200)),
             stop: jest.fn(),
@@ -193,8 +208,12 @@ describe('PlayScene authoritative resync', () => {
         handlers.auth_snapshot(snapshot);
         handlers.auth_snapshot(snapshot);
 
-        expect(deserializeEncoded).toHaveBeenCalledTimes(1);
-        expect(deserializeEncoded).toHaveBeenCalledWith('0'.repeat(200));
+        expect(applyAuthoritativeState).toHaveBeenCalledTimes(2);
+        expect(applyAuthoritativeState).toHaveBeenNthCalledWith(1,
+            snapshot.opponent.sync?.boardCore ?? snapshot.opponent.board,
+            snapshot.opponent.sync?.active ?? null,
+            snapshot.opponent.sync?.canHold ?? false,
+        );
     });
 
     test('does not resync local state while server ack is behind local predicted input seq', () => {
@@ -217,7 +236,7 @@ describe('PlayScene authoritative resync', () => {
         });
         Reflect.set(scene, 'inputManager', { isEnabled: true });
         Reflect.set(scene, 'inGameMenu', { isMenuOpen: false });
-        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded: jest.fn() });
+        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded: jest.fn(), applyAuthoritativeState: jest.fn() });
         Reflect.set(scene, 'playField', {
             serializeEncoded: jest.fn(() => '9'.repeat(200)),
             stop: jest.fn(),
@@ -407,7 +426,7 @@ describe('PlayScene authoritative resync', () => {
             { setVisible: setVisibleB },
         ]);
         Reflect.set(scene, 'awaitingInitialAuthSnapshot', true);
-        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded: jest.fn() });
+        Reflect.set(scene, 'opponentPlayField', { deserializeEncoded: jest.fn(), applyAuthoritativeState: jest.fn() });
         Reflect.set(scene, 'playField', {
             serializeEncoded: jest.fn(() => '9'.repeat(200)),
             stop: jest.fn(),


### PR DESCRIPTION
### Motivation
- The opponent mini/side playfield in 1:1 authoritative snapshots was sometimes missing the thin buffer-area occupancy because the scene used `opponent.board` (locked blocks) instead of the full authoritative `sync` payload containing `boardCore` + `active` piece state.  
- The intent is to render the opponent's active piece and buffer-row visuals when authoritative sync is present so the thin buffer area is visible to the player.

### Description
- Prefer authoritative opponent sync when available by calling `PlayField.applyAuthoritativeState(...)` with `opponent.sync.boardCore`, `opponent.sync.active`, and `opponent.sync.canHold` in `src/tetris/scenes/playScene.ts` and fall back to the previous `opponent.board` path when `sync` is absent.  
- Reset `lastOpponentBoardSnapshot` when applying authoritative sync to avoid desync dedup issues.  
- Updated the unit fixture and mocks in `test/unit/scenes/playScene.authoritativeResync.test.ts` to include `opponent.sync` and to assert `applyAuthoritativeState` usage instead of only `deserializeEncoded` so the behavior is covered.  
- Files changed: `src/tetris/scenes/playScene.ts` and `test/unit/scenes/playScene.authoritativeResync.test.ts`.

### Testing
- Ran the targeted scene test with `npm test -- --runTestsByPath test/unit/scenes/playScene.authoritativeResync.test.ts` and it passed.  
- Ran `npm test -- --runTestsByPath test/unit/scenes/nMultiPlayScene.payloadGuards.test.ts` and it passed.  
- Built the client with `npm run build` which completed successfully.  
- Attempted `npm run dev -- --host 0.0.0.0 --port 8080` but the dev server failed in this environment due to a system file-watcher limit (`ENOSPC`), so no live-dev verification was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3997f11c48320b3df67ca746da2bd)