### PR TITLE
Support short join URLs, parsing, and copy-join-URL overlay

### DIFF
--- a/src/tetris/net/joinUrl.ts
+++ b/src/tetris/net/joinUrl.ts
@@ -1,0 +1,57 @@
+export type JoinUrlMode = 'multi' | 'n-multi';
+
+export interface ParsedJoinTarget {
+    mode: JoinUrlMode;
+    roomKey: string;
+    useShortJoin: boolean;
+}
+
+function sanitizeBotLevel(raw: string | null): number {
+    const parsed = Number.parseInt(raw ?? '0', 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function buildJoinUrl(mode: JoinUrlMode, roomKey: string, useShortJoin: boolean = true): string {
+    const encodedRoomKey = encodeURIComponent(roomKey);
+    const path = useShortJoin ? `/j/${mode === 'multi' ? 'm' : 'n'}/${encodedRoomKey}` : `/${mode}/${encodedRoomKey}`;
+
+    if (typeof window === 'undefined' || typeof window.location?.origin !== 'string') {
+        return path;
+    }
+    return `${window.location.origin}${path}`;
+}
+
+export function parseJoinRoute(pathname: string): ParsedJoinTarget | null {
+    const shortMatch = pathname.match(/^\/j\/(m|n)\/(.+)$/);
+    if (shortMatch) {
+        return {
+            mode: shortMatch[1] === 'm' ? 'multi' : 'n-multi',
+            roomKey: decodeURIComponent(shortMatch[2]),
+            useShortJoin: true,
+        };
+    }
+
+    const longMatch = pathname.match(/^\/(multi|n-multi)\/(.+)$/);
+    if (longMatch) {
+        return {
+            mode: longMatch[1] as JoinUrlMode,
+            roomKey: decodeURIComponent(longMatch[2]),
+            useShortJoin: false,
+        };
+    }
+
+    return null;
+}
+
+export function resolveJoinRoute(pathname: string, search: string): (ParsedJoinTarget & { botLevel: number }) | null {
+    const target = parseJoinRoute(pathname);
+    if (!target) {
+        return null;
+    }
+
+    const urlParams = new URLSearchParams(search);
+    return {
+        ...target,
+        botLevel: sanitizeBotLevel(urlParams.get('bot')),
+    };
+}

--- a/src/tetris/scenes/basePlayScene.ts
+++ b/src/tetris/scenes/basePlayScene.ts
@@ -8,7 +8,7 @@ import { BotManager } from '../logic/botManager';
 import { CONST, InputDirection, InputState } from '../const/const';
 import { GAME_FONT_FAMILY } from '../ui/uiStyles';
 import { Socket } from 'socket.io-client';
-import { buildJoinUrl, JoinUrlMode } from '../net/joinUrl';
+import { JoinUrlMode } from '../net/joinUrl';
 import { playKenneyImpactSound } from '../ui/kenneyAssets';
 
 /**
@@ -80,24 +80,22 @@ export abstract class BasePlayScene extends BaseScene {
     }
 
     private handleCopyJoinUrl(): void {
-        const joinUrl = (this.joinUrlMode && this.joinUrlRoomKey)
-            ? buildJoinUrl(this.joinUrlMode, this.joinUrlRoomKey, true)
-            : this.resolveRootUrl();
+        const currentUrl = this.resolveCurrentUrl();
 
         if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
             return;
         }
 
-        void navigator.clipboard.writeText(joinUrl).then(() => {
+        void navigator.clipboard.writeText(currentUrl).then(() => {
             this.overlayControls?.showCopyToast();
         });
     }
 
-    private resolveRootUrl(): string {
-        if (typeof window === 'undefined' || typeof window.location?.origin !== 'string') {
+    private resolveCurrentUrl(): string {
+        if (typeof window === 'undefined' || typeof window.location?.href !== 'string') {
             return '/';
         }
-        return `${window.location.origin}/`;
+        return window.location.href;
     }
 
     protected toggleMenu(): void {

--- a/src/tetris/scenes/basePlayScene.ts
+++ b/src/tetris/scenes/basePlayScene.ts
@@ -8,6 +8,7 @@ import { BotManager } from '../logic/botManager';
 import { CONST, InputDirection, InputState } from '../const/const';
 import { GAME_FONT_FAMILY } from '../ui/uiStyles';
 import { Socket } from 'socket.io-client';
+import { buildJoinUrl, JoinUrlMode } from '../net/joinUrl';
 import { playKenneyImpactSound } from '../ui/kenneyAssets';
 
 /**
@@ -32,6 +33,8 @@ export abstract class BasePlayScene extends BaseScene {
     protected botLevel: number = 0;
     protected botManager: BotManager;
     protected overlayControls: GameOverlayControls | null = null;
+    protected joinUrlRoomKey: string | null = null;
+    protected joinUrlMode: JoinUrlMode | null = null;
     protected holdInputZone: Phaser.GameObjects.Zone | null = null;
     private escKeyHandler: (() => void) | null = null;
 
@@ -63,10 +66,38 @@ export abstract class BasePlayScene extends BaseScene {
         this.overlayControls = new GameOverlayControls({
             scene: this,
             onMenuClick: () => this.toggleMenu(),
+            onCopyJoinUrlClick: () => this.handleCopyJoinUrl(),
         });
 
         this.scale.on('resize', this.resize, this);
         this.resize(window.innerWidth, window.innerHeight);
+    }
+
+
+    protected configureJoinUrl(mode: JoinUrlMode | null, roomKey: string | null): void {
+        this.joinUrlMode = mode;
+        this.joinUrlRoomKey = roomKey;
+    }
+
+    private handleCopyJoinUrl(): void {
+        const joinUrl = (this.joinUrlMode && this.joinUrlRoomKey)
+            ? buildJoinUrl(this.joinUrlMode, this.joinUrlRoomKey, true)
+            : this.resolveRootUrl();
+
+        if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+            return;
+        }
+
+        void navigator.clipboard.writeText(joinUrl).then(() => {
+            this.overlayControls?.showCopyToast();
+        });
+    }
+
+    private resolveRootUrl(): string {
+        if (typeof window === 'undefined' || typeof window.location?.origin !== 'string') {
+            return '/';
+        }
+        return `${window.location.origin}/`;
     }
 
     protected toggleMenu(): void {

--- a/src/tetris/scenes/menuScene.ts
+++ b/src/tetris/scenes/menuScene.ts
@@ -2,6 +2,7 @@ import { CONST } from "../const/const";
 import { BaseScene } from "./baseScene";
 import { io, type Socket } from "socket.io-client";
 import { getSocketUrl, SOCKET_PATH } from "../net/socketUtils";
+import { resolveJoinRoute } from "../net/joinUrl";
 import { SocketListenerRegistry } from "../net/socketListenerRegistry";
 import { GAME_FONT_FAMILY, PANEL_BG } from "../ui/uiStyles";
 import { ensureGameFontReady } from "../ui/fontLoader";
@@ -88,21 +89,20 @@ export class MenuScene extends BaseScene {
         await ensureGameFontReady();
         if (this.isShuttingDown || !this.sys.isActive()) return;
 
-        const nMultiMatch = window.location.pathname.match(/^\/n-multi\/(.+)$/);
-        if (nMultiMatch) {
-            const roomName = decodeURIComponent(nMultiMatch[1]);
-            const urlParams = new URLSearchParams(window.location.search);
-            const botLevel = parseInt(urlParams.get('bot') || '0', 10);
-            this.joinNMultiRoomByUrl(roomName, botLevel);
+        const joinTarget = resolveJoinRoute(window.location.pathname, window.location.search);
+        if (joinTarget?.mode === 'n-multi') {
+            if (joinTarget.useShortJoin) {
+                history.replaceState(null, '', `/n-multi/${encodeURIComponent(joinTarget.roomKey)}${window.location.search}`);
+            }
+            this.joinNMultiRoomByUrl(joinTarget.roomKey, joinTarget.botLevel);
             return;
         }
 
-        const multiMatch = window.location.pathname.match(/^\/multi\/(.+)$/);
-        if (multiMatch) {
-            const roomName = decodeURIComponent(multiMatch[1]);
-            const urlParams = new URLSearchParams(window.location.search);
-            const botLevel = parseInt(urlParams.get('bot') || '0', 10);
-            this.joinMultiRoomByUrl(roomName, botLevel);
+        if (joinTarget?.mode === 'multi') {
+            if (joinTarget.useShortJoin) {
+                history.replaceState(null, '', `/multi/${encodeURIComponent(joinTarget.roomKey)}${window.location.search}`);
+            }
+            this.joinMultiRoomByUrl(joinTarget.roomKey, joinTarget.botLevel);
             return;
         }
 

--- a/src/tetris/scenes/nMultiPlayScene.ts
+++ b/src/tetris/scenes/nMultiPlayScene.ts
@@ -99,6 +99,7 @@ export class NMultiPlayScene extends BasePlayScene {
 
         this.socket = data.socket;
         this.roomId = data.roomId;
+        this.configureJoinUrl('n-multi', this.roomId);
         this.roomName = data.roomName;
         this.playerId = data.playerId;
         this.playerName = data.playerName;

--- a/src/tetris/scenes/playScene.ts
+++ b/src/tetris/scenes/playScene.ts
@@ -428,6 +428,7 @@ export class PlayScene extends BasePlayScene {
 
         this.mode = data.mode || 'single';
         this.roomName = data.roomName;
+        this.configureJoinUrl(null, null);
         this.botLevel = data.botLevel || 0;
         this.isHost = false;
         this.authQueueSeed = null;
@@ -440,6 +441,7 @@ export class PlayScene extends BasePlayScene {
             this.authQueueSeed = toFiniteNumberOrNull(data.authQueueSeed);
             this.initialAuthSnapshot = isAuthSnapshotPayload(data.authSnapshot) ? data.authSnapshot : null;
             this.useAuthoritativeServer = true;
+            this.configureJoinUrl('multi', this.roomId);
         }
 
         const dims = calcPlaySceneDimensions(this.layoutMode, this.mode);

--- a/src/tetris/ui/gameOverlayControls.ts
+++ b/src/tetris/ui/gameOverlayControls.ts
@@ -58,10 +58,10 @@ export class GameOverlayControls {
         this.menuLabel.setStroke('#00111f', 2);
         this.menuLabel.setShadow(1, 1, '#00111f', 1, true, true);
 
-        this.copyJoinLabel = this.scene.add.text(0, 0, 'Copy Join URL', {
+        this.copyJoinLabel = this.scene.add.text(0, 0, 'Copy Url', {
             ...TextStyles.header,
             align: 'center',
-            fontSize: '13px',
+            fontSize: '16px',
             color: '#f8fdff',
         }).setOrigin(0.5);
         this.copyJoinLabel.setStroke('#00111f', 2);
@@ -165,10 +165,10 @@ export class GameOverlayControls {
         this.menuLabel.setFontSize(`${menuFontSize}px`);
 
         const copyJoinWidth = this.onCopyJoinUrlClick
-            ? Math.max(menuHeight * 3.2, Math.min(viewWidth * 0.32, menuHeight * 4.9))
+            ? Math.min(menuHeight * 2.45, Math.max(menuHeight * 1.9, viewWidth * 0.19))
             : 0;
         const copyJoinGap = this.onCopyJoinUrlClick ? Math.max(4, Math.round(menuHeight * 0.14)) : 0;
-        const copyJoinFontSize = Math.max(9, Math.round(menuHeight * 0.33));
+        const copyJoinFontSize = Math.max(10, Math.round(menuHeight * 0.45));
         this.copyJoinLabel.setFontSize(`${copyJoinFontSize}px`);
 
         const guideFontSize = isMobilePortrait
@@ -257,6 +257,7 @@ export class GameOverlayControls {
             label: this.menuLabel,
             hitArea: this.menuHitArea,
             pressed: this.menuPressed,
+            theme: 'blue',
         });
     }
 
@@ -270,6 +271,7 @@ export class GameOverlayControls {
             label: this.copyJoinLabel,
             hitArea: this.copyJoinHitArea,
             pressed: this.copyJoinPressed,
+            theme: 'green',
         });
     }
 
@@ -278,6 +280,7 @@ export class GameOverlayControls {
         label: Phaser.GameObjects.Text;
         hitArea: Phaser.GameObjects.Rectangle;
         pressed: boolean;
+        theme: 'blue' | 'green';
     }): void {
         const x = options.hitArea.x;
         const y = options.hitArea.y;
@@ -289,13 +292,28 @@ export class GameOverlayControls {
 
         options.background.clear();
 
-        const baseColor = options.pressed ? 0x0b3d59 : 0x0f5f82;
-        const innerColor = options.pressed ? 0x155272 : 0x1b749d;
+        const palette = options.theme === 'green'
+            ? {
+                baseColor: options.pressed ? 0x14532d : 0x166534,
+                innerColor: options.pressed ? 0x15803d : 0x16a34a,
+                outerStrokeColor: 0xbbf7d0,
+                glowColor: 0x86efac,
+                labelPressedColor: '#dcfce7',
+                labelColor: '#f0fdf4',
+            }
+            : {
+                baseColor: options.pressed ? 0x0b3d59 : 0x0f5f82,
+                innerColor: options.pressed ? 0x155272 : 0x1b749d,
+                outerStrokeColor: 0xbef8ff,
+                glowColor: 0x67e8f9,
+                labelPressedColor: '#dbeafe',
+                labelColor: '#f0fbff',
+            };
 
-        options.background.fillStyle(baseColor, 1);
+        options.background.fillStyle(palette.baseColor, 1);
         options.background.fillRoundedRect(x, y, width, height, radius);
 
-        options.background.fillStyle(innerColor, options.pressed ? 0.85 : 0.9);
+        options.background.fillStyle(palette.innerColor, options.pressed ? 0.85 : 0.9);
         options.background.fillRoundedRect(
             x + insetA,
             y + insetA,
@@ -313,7 +331,7 @@ export class GameOverlayControls {
             Math.max(2, radius - insetB),
         );
 
-        options.background.lineStyle(2, 0xbef8ff, options.pressed ? 0.85 : 0.95);
+        options.background.lineStyle(2, palette.outerStrokeColor, options.pressed ? 0.85 : 0.95);
         options.background.strokeRoundedRect(
             x + insetA / 2,
             y + insetA / 2,
@@ -332,11 +350,11 @@ export class GameOverlayControls {
         );
 
         if (!options.pressed) {
-            options.background.lineStyle(1, 0x67e8f9, 0.28);
+            options.background.lineStyle(1, palette.glowColor, 0.28);
             options.background.strokeRoundedRect(x - insetA / 2, y - insetA / 2, width + insetA, height + insetA, radius + insetA / 2);
         }
 
-        options.label.setColor(options.pressed ? '#dbeafe' : '#f0fbff');
+        options.label.setColor(options.pressed ? palette.labelPressedColor : palette.labelColor);
         options.label.setPosition(x + width / 2, y + height / 2 + (options.pressed ? Math.max(1, insetA * 0.5) : 0));
         this.root.bringToTop(options.label);
     }

--- a/src/tetris/ui/gameOverlayControls.ts
+++ b/src/tetris/ui/gameOverlayControls.ts
@@ -4,6 +4,7 @@ import { getBlockSize } from "../const/const";
 interface OverlayControlOptions {
     scene: Phaser.Scene;
     onMenuClick: () => void;
+    onCopyJoinUrlClick?: () => void;
 }
 
 type GuidePartKind = 'action' | 'key' | 'sep';
@@ -16,26 +17,37 @@ interface GuidePart {
 export class GameOverlayControls {
     private readonly scene: Phaser.Scene;
     private readonly onMenuClick: () => void;
+    private readonly onCopyJoinUrlClick: (() => void) | null;
 
     private root: Phaser.GameObjects.Container;
     private navBackground: Phaser.GameObjects.Graphics;
     private menuBackground: Phaser.GameObjects.Graphics;
     private menuLabel: Phaser.GameObjects.Text;
+    private copyJoinBackground: Phaser.GameObjects.Graphics;
+    private copyJoinLabel: Phaser.GameObjects.Text;
     private guideContainer: Phaser.GameObjects.Container;
     private guideTexts: Phaser.GameObjects.Text[] = [];
     private menuHitArea: Phaser.GameObjects.Rectangle;
+    private copyJoinHitArea: Phaser.GameObjects.Rectangle;
+    private copyToastContainer: Phaser.GameObjects.Container;
+    private copyToastBg: Phaser.GameObjects.Graphics;
+    private copyToastLabel: Phaser.GameObjects.Text;
+    private copyToastTimer: Phaser.Time.TimerEvent | null = null;
 
     private menuPressed: boolean = false;
+    private copyJoinPressed: boolean = false;
     private destroyed: boolean = false;
 
     constructor(options: OverlayControlOptions) {
         this.scene = options.scene;
         this.onMenuClick = options.onMenuClick;
+        this.onCopyJoinUrlClick = options.onCopyJoinUrlClick ?? null;
 
         this.root = this.scene.add.container(0, 0).setDepth(3000);
 
         this.navBackground = this.scene.add.graphics();
         this.menuBackground = this.scene.add.graphics();
+        this.copyJoinBackground = this.scene.add.graphics();
 
         this.menuLabel = this.scene.add.text(0, 0, 'MENU', {
             ...TextStyles.header,
@@ -45,6 +57,16 @@ export class GameOverlayControls {
         }).setOrigin(0.5);
         this.menuLabel.setStroke('#00111f', 2);
         this.menuLabel.setShadow(1, 1, '#00111f', 1, true, true);
+
+        this.copyJoinLabel = this.scene.add.text(0, 0, 'Copy Join URL', {
+            ...TextStyles.header,
+            align: 'center',
+            fontSize: '13px',
+            color: '#f8fdff',
+        }).setOrigin(0.5);
+        this.copyJoinLabel.setStroke('#00111f', 2);
+        this.copyJoinLabel.setShadow(1, 1, '#00111f', 1, true, true);
+        this.copyJoinLabel.setVisible(Boolean(this.onCopyJoinUrlClick));
 
         this.guideContainer = this.scene.add.container(0, 0);
 
@@ -65,7 +87,56 @@ export class GameOverlayControls {
             this.drawMenuButton();
         });
 
-        this.root.add([this.navBackground, this.menuBackground, this.menuHitArea, this.menuLabel, this.guideContainer]);
+        this.copyJoinHitArea = this.scene.add.rectangle(0, 0, 1, 1, 0x000000, 0);
+        this.copyJoinHitArea.setOrigin(0, 0);
+        this.copyJoinHitArea.setVisible(Boolean(this.onCopyJoinUrlClick));
+        if (this.onCopyJoinUrlClick) {
+            this.copyJoinHitArea.setInteractive({ useHandCursor: true });
+            this.copyJoinHitArea.on('pointerdown', () => {
+                this.copyJoinPressed = true;
+                this.drawCopyJoinButton();
+            });
+            this.copyJoinHitArea.on('pointerup', () => {
+                this.copyJoinPressed = false;
+                this.drawCopyJoinButton();
+                this.onCopyJoinUrlClick?.();
+            });
+            this.copyJoinHitArea.on('pointerout', () => {
+                this.copyJoinPressed = false;
+                this.drawCopyJoinButton();
+            });
+        }
+
+        this.copyToastBg = this.scene.add.graphics();
+        this.copyToastLabel = this.scene.add.text(0, 0, 'URL Copied', {
+            ...TextStyles.label,
+            align: 'center',
+            fontSize: '14px',
+            color: '#e2e8f0',
+            stroke: '#020b14',
+            strokeThickness: 2,
+            shadow: {
+                offsetX: 1,
+                offsetY: 1,
+                color: '#000000',
+                blur: 1,
+                stroke: true,
+                fill: true,
+            },
+        }).setOrigin(0.5);
+        this.copyToastContainer = this.scene.add.container(0, 0, [this.copyToastBg, this.copyToastLabel]).setVisible(false);
+
+        this.root.add([
+            this.navBackground,
+            this.menuBackground,
+            this.copyJoinBackground,
+            this.menuHitArea,
+            this.copyJoinHitArea,
+            this.menuLabel,
+            this.copyJoinLabel,
+            this.guideContainer,
+            this.copyToastContainer,
+        ]);
         this.layout();
     }
 
@@ -88,10 +159,17 @@ export class GameOverlayControls {
         const horizontalPadding = barHeight * 0.22;
         const verticalPadding = barHeight * 0.12;
         const menuHeight = Math.max(1, barHeight - verticalPadding * 2);
-        const menuWidth = Math.min(menuHeight * 2.45, Math.max(menuHeight * 1.9, viewWidth * 0.26));
+        const menuWidth = Math.min(menuHeight * 2.45, Math.max(menuHeight * 1.9, viewWidth * 0.18));
 
         const menuFontSize = Math.max(10, Math.round(menuHeight * 0.46));
         this.menuLabel.setFontSize(`${menuFontSize}px`);
+
+        const copyJoinWidth = this.onCopyJoinUrlClick
+            ? Math.max(menuHeight * 3.2, Math.min(viewWidth * 0.32, menuHeight * 4.9))
+            : 0;
+        const copyJoinGap = this.onCopyJoinUrlClick ? Math.max(4, Math.round(menuHeight * 0.14)) : 0;
+        const copyJoinFontSize = Math.max(9, Math.round(menuHeight * 0.33));
+        this.copyJoinLabel.setFontSize(`${copyJoinFontSize}px`);
 
         const guideFontSize = isMobilePortrait
             ? Math.max(9, Math.round(menuHeight * 0.34))
@@ -105,10 +183,47 @@ export class GameOverlayControls {
         this.menuLabel.setPosition(horizontalPadding + menuWidth / 2, barHeight / 2);
         this.drawMenuButton();
 
-        const availableGuideWidth = Math.max(getBlockSize() * 2.5, viewWidth - (horizontalPadding * 3 + menuWidth));
+        if (this.onCopyJoinUrlClick) {
+            const copyX = horizontalPadding + menuWidth + copyJoinGap;
+            this.copyJoinHitArea.setPosition(copyX, verticalPadding);
+            this.copyJoinHitArea.setSize(copyJoinWidth, menuHeight);
+            this.copyJoinLabel.setPosition(copyX + copyJoinWidth / 2, barHeight / 2);
+            this.drawCopyJoinButton();
+        }
+
+        const availableGuideWidth = Math.max(
+            getBlockSize() * 2.5,
+            viewWidth - (horizontalPadding * 3 + menuWidth + copyJoinGap + copyJoinWidth),
+        );
         const guideParts = this.resolveGuideParts(isMobilePortrait, viewWidthPx);
         this.renderGuide(guideParts, guideFontSize, availableGuideWidth);
         this.guideContainer.setPosition(viewWidth - horizontalPadding, barHeight / 2);
+        this.layoutCopyToast(viewWidth, barHeight);
+    }
+
+    public showCopyToast(): void {
+        if (this.destroyed || !this.copyToastContainer.scene) {
+            return;
+        }
+
+        if (this.copyToastTimer) {
+            this.copyToastTimer.remove(false);
+            this.copyToastTimer = null;
+        }
+
+        this.copyToastContainer.setAlpha(1);
+        this.copyToastContainer.setVisible(true);
+        this.copyToastTimer = this.scene.time.delayedCall(1050, () => {
+            this.scene.tweens.add({
+                targets: this.copyToastContainer,
+                alpha: 0,
+                duration: 180,
+                onComplete: () => {
+                    this.copyToastContainer.setVisible(false);
+                    this.copyToastContainer.setAlpha(1);
+                },
+            });
+        });
     }
 
     public destroy() {
@@ -116,6 +231,10 @@ export class GameOverlayControls {
             return;
         }
         this.destroyed = true;
+        if (this.copyToastTimer) {
+            this.copyToastTimer.remove(false);
+            this.copyToastTimer = null;
+        }
         this.root.destroy(true);
     }
 
@@ -133,24 +252,51 @@ export class GameOverlayControls {
             return;
         }
 
-        const x = this.menuHitArea.x;
-        const y = this.menuHitArea.y;
-        const width = this.menuHitArea.width;
-        const height = this.menuHitArea.height;
+        this.drawControlButton({
+            background: this.menuBackground,
+            label: this.menuLabel,
+            hitArea: this.menuHitArea,
+            pressed: this.menuPressed,
+        });
+    }
+
+    private drawCopyJoinButton() {
+        if (this.destroyed || !this.copyJoinHitArea.scene || !this.onCopyJoinUrlClick) {
+            return;
+        }
+
+        this.drawControlButton({
+            background: this.copyJoinBackground,
+            label: this.copyJoinLabel,
+            hitArea: this.copyJoinHitArea,
+            pressed: this.copyJoinPressed,
+        });
+    }
+
+    private drawControlButton(options: {
+        background: Phaser.GameObjects.Graphics;
+        label: Phaser.GameObjects.Text;
+        hitArea: Phaser.GameObjects.Rectangle;
+        pressed: boolean;
+    }): void {
+        const x = options.hitArea.x;
+        const y = options.hitArea.y;
+        const width = options.hitArea.width;
+        const height = options.hitArea.height;
         const radius = Math.max(4, Math.round(height * 0.24));
         const insetA = Math.max(1, Math.round(height * 0.06));
         const insetB = insetA + Math.max(1, Math.round(height * 0.04));
 
-        this.menuBackground.clear();
+        options.background.clear();
 
-        const baseColor = this.menuPressed ? 0x0b3d59 : 0x0f5f82;
-        const innerColor = this.menuPressed ? 0x155272 : 0x1b749d;
+        const baseColor = options.pressed ? 0x0b3d59 : 0x0f5f82;
+        const innerColor = options.pressed ? 0x155272 : 0x1b749d;
 
-        this.menuBackground.fillStyle(baseColor, 1);
-        this.menuBackground.fillRoundedRect(x, y, width, height, radius);
+        options.background.fillStyle(baseColor, 1);
+        options.background.fillRoundedRect(x, y, width, height, radius);
 
-        this.menuBackground.fillStyle(innerColor, this.menuPressed ? 0.85 : 0.9);
-        this.menuBackground.fillRoundedRect(
+        options.background.fillStyle(innerColor, options.pressed ? 0.85 : 0.9);
+        options.background.fillRoundedRect(
             x + insetA,
             y + insetA,
             Math.max(1, width - insetA * 2),
@@ -158,8 +304,8 @@ export class GameOverlayControls {
             Math.max(2, radius - insetA),
         );
 
-        this.menuBackground.fillStyle(0xffffff, this.menuPressed ? 0.08 : 0.16);
-        this.menuBackground.fillRoundedRect(
+        options.background.fillStyle(0xffffff, options.pressed ? 0.08 : 0.16);
+        options.background.fillRoundedRect(
             x + insetB,
             y + insetB,
             Math.max(1, width - insetB * 2),
@@ -167,8 +313,8 @@ export class GameOverlayControls {
             Math.max(2, radius - insetB),
         );
 
-        this.menuBackground.lineStyle(2, 0xbef8ff, this.menuPressed ? 0.85 : 0.95);
-        this.menuBackground.strokeRoundedRect(
+        options.background.lineStyle(2, 0xbef8ff, options.pressed ? 0.85 : 0.95);
+        options.background.strokeRoundedRect(
             x + insetA / 2,
             y + insetA / 2,
             Math.max(1, width - insetA),
@@ -176,8 +322,8 @@ export class GameOverlayControls {
             Math.max(2, radius - insetA / 2),
         );
 
-        this.menuBackground.lineStyle(1, 0x062334, this.menuPressed ? 0.65 : 0.5);
-        this.menuBackground.strokeRoundedRect(
+        options.background.lineStyle(1, 0x062334, options.pressed ? 0.65 : 0.5);
+        options.background.strokeRoundedRect(
             x + insetB,
             y + insetB,
             Math.max(1, width - insetB * 2),
@@ -185,14 +331,34 @@ export class GameOverlayControls {
             Math.max(2, radius - insetB),
         );
 
-        if (!this.menuPressed) {
-            this.menuBackground.lineStyle(1, 0x67e8f9, 0.28);
-            this.menuBackground.strokeRoundedRect(x - insetA / 2, y - insetA / 2, width + insetA, height + insetA, radius + insetA / 2);
+        if (!options.pressed) {
+            options.background.lineStyle(1, 0x67e8f9, 0.28);
+            options.background.strokeRoundedRect(x - insetA / 2, y - insetA / 2, width + insetA, height + insetA, radius + insetA / 2);
         }
 
-        this.menuLabel.setColor(this.menuPressed ? '#dbeafe' : '#f0fbff');
-        this.menuLabel.setPosition(x + width / 2, y + height / 2 + (this.menuPressed ? Math.max(1, insetA * 0.5) : 0));
-        this.root.bringToTop(this.menuLabel);
+        options.label.setColor(options.pressed ? '#dbeafe' : '#f0fbff');
+        options.label.setPosition(x + width / 2, y + height / 2 + (options.pressed ? Math.max(1, insetA * 0.5) : 0));
+        this.root.bringToTop(options.label);
+    }
+
+    private layoutCopyToast(viewWidth: number, barHeight: number): void {
+        if (this.destroyed || !this.copyToastContainer.scene) {
+            return;
+        }
+        const toastWidth = Math.max(120, Math.min(220, viewWidth * 0.3));
+        const toastHeight = Math.max(24, Math.round(barHeight * 0.75));
+        const toastX = Math.round(viewWidth / 2);
+        const toastY = Math.round(barHeight + toastHeight * 0.62);
+
+        this.copyToastBg.clear();
+        this.copyToastBg.fillStyle(PANEL_BG.fillColor, 0.95);
+        this.copyToastBg.fillRoundedRect(-toastWidth / 2, -toastHeight / 2, toastWidth, toastHeight, 6);
+        this.copyToastBg.lineStyle(2, PANEL_BG.strokeColor, PANEL_BG.strokeAlpha);
+        this.copyToastBg.strokeRoundedRect(-toastWidth / 2, -toastHeight / 2, toastWidth, toastHeight, 6);
+
+        this.copyToastLabel.setFontSize(`${Math.max(11, Math.round(toastHeight * 0.48))}px`);
+        this.copyToastLabel.setPosition(0, 0);
+        this.copyToastContainer.setPosition(toastX, toastY);
     }
 
     private resolveGuideParts(isMobilePortrait: boolean, viewWidth: number): GuidePart[] {

--- a/test/unit/net/joinUrl.test.ts
+++ b/test/unit/net/joinUrl.test.ts
@@ -1,0 +1,36 @@
+import { buildJoinUrl, parseJoinRoute, resolveJoinRoute } from '../../../src/tetris/net/joinUrl';
+
+describe('joinUrl helpers', () => {
+    test('buildJoinUrl returns short route by default', () => {
+        expect(buildJoinUrl('multi', 'room#1')).toBe(`${window.location.origin}/j/m/room%231`);
+        expect(buildJoinUrl('n-multi', 'room alpha')).toBe(`${window.location.origin}/j/n/room%20alpha`);
+    });
+
+    test('parseJoinRoute supports short and legacy paths', () => {
+        expect(parseJoinRoute('/j/m/room-1')).toEqual({
+            mode: 'multi',
+            roomKey: 'room-1',
+            useShortJoin: true,
+        });
+        expect(parseJoinRoute('/n-multi/Room%20A')).toEqual({
+            mode: 'n-multi',
+            roomKey: 'Room A',
+            useShortJoin: false,
+        });
+    });
+
+    test('resolveJoinRoute returns bot level with defaults', () => {
+        expect(resolveJoinRoute('/j/n/abc', '?bot=9')).toEqual({
+            mode: 'n-multi',
+            roomKey: 'abc',
+            useShortJoin: true,
+            botLevel: 9,
+        });
+        expect(resolveJoinRoute('/multi/abc', '')).toEqual({
+            mode: 'multi',
+            roomKey: 'abc',
+            useShortJoin: false,
+            botLevel: 0,
+        });
+    });
+});

--- a/test/unit/scenes/menuScene.urlRouting.test.ts
+++ b/test/unit/scenes/menuScene.urlRouting.test.ts
@@ -65,6 +65,43 @@ describe('MenuScene URL join flow', () => {
         expect(scene.createPhaserUI).not.toHaveBeenCalled();
     });
 
+
+    test('initializeMenuFlow routes short n-multi URL with room id and bot level', async () => {
+        setPath('/j/n/room-raw-id?bot=11');
+        const scene = new MenuScene() as any;
+        scene.sys = { isActive: () => true };
+        scene.isShuttingDown = false;
+        scene.joinNMultiRoomByUrl = jest.fn();
+        scene.joinMultiRoomByUrl = jest.fn();
+        scene.createPhaserUI = jest.fn();
+        scene.resize = jest.fn();
+        const replaceSpy = jest.spyOn(history, 'replaceState');
+
+        await scene.initializeMenuFlow();
+
+        expect(replaceSpy).toHaveBeenCalledWith(null, '', '/n-multi/room-raw-id?bot=11');
+        expect(scene.joinNMultiRoomByUrl).toHaveBeenCalledWith('room-raw-id', 11);
+        expect(scene.joinMultiRoomByUrl).not.toHaveBeenCalled();
+    });
+
+    test('initializeMenuFlow routes short multi URL with room id and bot level', async () => {
+        setPath('/j/m/duel-room-id?bot=3');
+        const scene = new MenuScene() as any;
+        scene.sys = { isActive: () => true };
+        scene.isShuttingDown = false;
+        scene.joinNMultiRoomByUrl = jest.fn();
+        scene.joinMultiRoomByUrl = jest.fn();
+        scene.createPhaserUI = jest.fn();
+        scene.resize = jest.fn();
+        const replaceSpy = jest.spyOn(history, 'replaceState');
+
+        await scene.initializeMenuFlow();
+
+        expect(replaceSpy).toHaveBeenCalledWith(null, '', '/multi/duel-room-id?bot=3');
+        expect(scene.joinMultiRoomByUrl).toHaveBeenCalledWith('duel-room-id', 3);
+        expect(scene.joinNMultiRoomByUrl).not.toHaveBeenCalled();
+    });
+
     test('initializeMenuFlow falls back to menu UI on root path', async () => {
         setPath('/');
         const scene = new MenuScene() as any;
@@ -119,6 +156,39 @@ describe('MenuScene URL join flow', () => {
             authQueueSeed: 777,
         }));
         expect(socket.off).toHaveBeenCalledTimes(4);
+    });
+
+
+    test('joinMultiRoomByUrl keeps join_or_create behavior for any route source', () => {
+        const handlers: SocketHandlerMap = {};
+        const socket = createSocket(handlers);
+        const scene = new MenuScene() as any;
+        scene.createConnectingText = jest.fn();
+        scene.createUrlJoinSocket = jest.fn(() => {
+            scene.urlJoinSocket = socket;
+            return socket;
+        });
+
+        scene.joinMultiRoomByUrl('room-id-55', 4);
+        handlers.connect();
+
+        expect(socket.emit).toHaveBeenCalledWith('join_or_create', { roomName: 'room-id-55', botLevel: 4 });
+    });
+
+    test('joinNMultiRoomByUrl keeps nmulti_join_or_create behavior for any route source', () => {
+        const handlers: SocketHandlerMap = {};
+        const socket = createSocket(handlers);
+        const scene = new MenuScene() as any;
+        scene.createConnectingText = jest.fn();
+        scene.createUrlJoinSocket = jest.fn(() => {
+            scene.urlJoinSocket = socket;
+            return socket;
+        });
+
+        scene.joinNMultiRoomByUrl('n-room-id-55', 6);
+        handlers.connect();
+
+        expect(socket.emit).toHaveBeenCalledWith('nmulti_join_or_create', { roomName: 'n-room-id-55', botLevel: 6 });
     });
 
     test('joinNMultiRoomByUrl recovers when room payload is malformed', () => {


### PR DESCRIPTION
### Motivation

- Provide a robust way to build, parse, and resolve both short (`/j/...`) and legacy (`/multi` / `/n-multi`) join routes and surface a convenient "Copy Join URL" action in-game.

### Description

- Added `src/tetris/net/joinUrl.ts` with `buildJoinUrl`, `parseJoinRoute`, `resolveJoinRoute`, and `sanitizeBotLevel` to handle encoding, short/long routes, and `bot` query parsing.
- Integrated join-route handling into `MenuScene.initializeMenuFlow` using `resolveJoinRoute`, and normalize short routes to canonical long routes via `history.replaceState` before joining.
- Exposed `configureJoinUrl`, `handleCopyJoinUrl`, and `resolveRootUrl` in `BasePlayScene` and wired calls from `PlayScene` and `NMultiPlayScene` to populate join metadata for copy behavior.
- Extended `GameOverlayControls` to optionally show a `Copy Join URL` button, added shared `drawControlButton` helper, a copy toast (`showCopyToast`), layout adjustments, and pointer handlers that call back to `BasePlayScene`.
- Added unit tests for the join URL helpers and expanded menu scene URL routing tests in `test/unit/net/joinUrl.test.ts` and updated `test/unit/scenes/menuScene.urlRouting.test.ts` to cover short-route flows and preserved join behavior.

### Testing

- Ran unit tests covering join URL helpers and menu routing (`test/unit/net/joinUrl.test.ts` and updated `test/unit/scenes/menuScene.urlRouting.test.ts`).
- All added and existing unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39d0fd4a88320ae603c528847bc10)